### PR TITLE
Polish poker draw flow and all-in announcements

### DIFF
--- a/server/games/fivecarddraw/game.py
+++ b/server/games/fivecarddraw/game.py
@@ -19,9 +19,10 @@ from ...game_utils.poker_evaluator import best_hand, describe_hand, describe_par
 from ...game_utils.poker_actions import compute_pot_limit_caps, clamp_total_to_cap
 from ...game_utils import poker_log
 from ...game_utils.poker_state import order_after_button
-from ...game_utils.poker_showdown import order_winners_by_button
+from ...game_utils.poker_showdown import order_winners_by_button, format_showdown_lines
 from ...game_utils.poker_payout import resolve_pot
 from ...messages.localization import Localization
+from ...users.preferences import DiceKeepingStyle
 from ...ui.keybinds import KeybindState
 from .bot import bot_think
 
@@ -129,6 +130,7 @@ class FiveCardDrawGame(Game):
     phase: str = "lobby"
     current_bet_round: int = 0
     action_log: list[tuple[str, dict]] = field(default_factory=list)
+    last_showdown_winner_ids: set[str] = field(default_factory=set)
 
     @classmethod
     def get_name(cls) -> str:
@@ -188,8 +190,8 @@ class FiveCardDrawGame(Game):
                 id="call",
                 label=Localization.get(locale, "poker-call"),
                 handler="_action_call",
-                is_enabled="_is_turn_action_enabled",
-                is_hidden="_is_turn_action_hidden",
+                is_enabled="_is_bet_action_enabled",
+                is_hidden="_is_bet_action_hidden",
             )
         )
         action_set.add(
@@ -197,8 +199,8 @@ class FiveCardDrawGame(Game):
                 id="fold",
                 label=Localization.get(locale, "poker-fold"),
                 handler="_action_fold",
-                is_enabled="_is_turn_action_enabled",
-                is_hidden="_is_turn_action_hidden",
+                is_enabled="_is_bet_action_enabled",
+                is_hidden="_is_bet_action_hidden",
             )
         )
         action_set.add(
@@ -206,8 +208,8 @@ class FiveCardDrawGame(Game):
                 id="raise",
                 label=Localization.get(locale, "poker-raise"),
                 handler="_action_raise",
-                is_enabled="_is_turn_action_enabled",
-                is_hidden="_is_turn_action_hidden",
+                is_enabled="_is_bet_action_enabled",
+                is_hidden="_is_bet_action_hidden",
                 input_request=EditboxInput(
                     prompt="poker-enter-raise",
                     default="",
@@ -220,8 +222,8 @@ class FiveCardDrawGame(Game):
                 id="all_in",
                 label=Localization.get(locale, "poker-all-in"),
                 handler="_action_all_in",
-                is_enabled="_is_turn_action_enabled",
-                is_hidden="_is_turn_action_hidden",
+                is_enabled="_is_bet_action_enabled",
+                is_hidden="_is_bet_action_hidden",
             )
         )
         action_set.add(
@@ -231,8 +233,28 @@ class FiveCardDrawGame(Game):
                 handler="_action_draw_cards",
                 is_enabled="_is_draw_enabled",
                 is_hidden="_is_draw_hidden",
+                get_label="_get_draw_label",
             )
         )
+        for i in range(1, 6):
+            action_set.add(
+                Action(
+                    id=f"card_key_{i}",
+                    label=f"Card key {i}",
+                    handler="_action_card_key",
+                    is_enabled="_is_discard_toggle_enabled",
+                    is_hidden="_is_always_hidden",
+                )
+            )
+            action_set.add(
+                Action(
+                    id=f"card_discard_{i}",
+                    label=f"Discard card {i}",
+                    handler="_action_card_discard",
+                    is_enabled="_is_discard_toggle_enabled",
+                    is_hidden="_is_always_hidden",
+                )
+            )
         for i in range(1, 6):
             action_set.add(
                 Action(
@@ -241,6 +263,7 @@ class FiveCardDrawGame(Game):
                     handler="_action_toggle_discard",
                     is_enabled="_is_discard_toggle_enabled",
                     is_hidden="_is_discard_toggle_hidden",
+                    get_label="_get_toggle_discard_label",
                 )
             )
         return action_set
@@ -348,7 +371,7 @@ class FiveCardDrawGame(Game):
         self.define_keybind("f", "Fold", ["fold"])
         self.define_keybind("c", "Call/Check", ["call"])
         self.define_keybind("r", "Raise", ["raise"])
-        self.define_keybind("A", "All in", ["all_in"])
+        self.define_keybind("shift+a", "All in", ["all_in"])
         self.define_keybind("d", "Read hand", ["speak_hand"], include_spectators=False)
         self.define_keybind("g", "Hand value", ["speak_hand_value"], include_spectators=False)
         self.define_keybind("x", "Dealer", ["check_dealer"], include_spectators=True)
@@ -359,7 +382,18 @@ class FiveCardDrawGame(Game):
         self.define_keybind("T", "Turn timer", ["check_turn_timer"], include_spectators=True)
         self.define_keybind("v", "Raise mode", ["check_raise_mode"], include_spectators=True)
         for i in range(1, 6):
-            self.define_keybind(str(i), f"Read card {i}", [f"speak_card_{i}"], include_spectators=False)
+            self.define_keybind(
+                str(i),
+                f"Card key {i}",
+                [f"card_key_{i}"],
+                state=KeybindState.ACTIVE,
+            )
+            self.define_keybind(
+                f"shift+{i}",
+                f"Discard card {i}",
+                [f"card_discard_{i}"],
+                state=KeybindState.ACTIVE,
+            )
 
     # ==========================================================================
     # Game flow
@@ -396,12 +430,17 @@ class FiveCardDrawGame(Game):
             p.hand = []
             p.folded = False
             p.all_in = False
+            p.to_discard = set()
             p.bet_this_round = 0
             p.to_discard = set()
 
         self.play_sound("game_cards/small_shuffle.ogg")
         self._post_ante(active)
         self._deal_cards(active, 5)
+        for p in active:
+            user = self.get_user(p)
+            if user:
+                user.speak_l("draw-dealt-cards", cards=read_cards(p.hand, user.locale))
         self._start_betting_round(start_index=-1)
 
     def _post_ante(self, active: list[FiveCardDrawPlayer]) -> None:
@@ -480,7 +519,7 @@ class FiveCardDrawGame(Game):
             return
         self.announce_turn(turn_sound="game_3cardpoker/turn.ogg")
         if p.is_bot:
-            BotHelper.jolt_bot(p, ticks=random.randint(5, 10))
+            BotHelper.jolt_bot(p, ticks=random.randint(30, 50))
         self._start_turn_timer()
         self.rebuild_all_menus()
 
@@ -508,6 +547,11 @@ class FiveCardDrawGame(Game):
         super().on_tick()
         self.process_scheduled_sounds()
         if not self.game_active:
+            return
+        if getattr(self, "_next_hand_wait_ticks", 0) > 0:
+            self._next_hand_wait_ticks -= 1
+            if self._next_hand_wait_ticks == 0:
+                self._start_new_hand()
             return
         if self.timer.tick():
             self._handle_turn_timeout()
@@ -547,6 +591,8 @@ class FiveCardDrawGame(Game):
             self.play_sound("game_3cardpoker/bet.ogg")
             poker_log.log_call(self.action_log, p.name, pay)
             self.broadcast_l("poker-player-calls", player=p.name, amount=pay)
+        if p.all_in and pay > 0:
+            self.broadcast_l("poker-player-all-in", player=p.name, amount=pay)
         self._sync_team_scores()
         self._after_action()
 
@@ -592,6 +638,8 @@ class FiveCardDrawGame(Game):
         self.betting.record_bet(p.id, total, is_raise=True)
         poker_log.log_raise(self.action_log, p.name, total)
         self.broadcast_l("poker-player-raises", player=p.name, amount=total)
+        if p.all_in:
+            self.broadcast_l("poker-player-all-in", player=p.name, amount=total)
         self._sync_team_scores()
         self._after_action()
 
@@ -635,6 +683,8 @@ class FiveCardDrawGame(Game):
         else:
             poker_log.log_call(self.action_log, p.name, pay)
             self.broadcast_l("poker-player-calls", player=p.name, amount=pay)
+        if p.all_in:
+            self.broadcast_l("poker-player-all-in", player=p.name, amount=pay)
         self._sync_team_scores()
         self._after_action()
 
@@ -647,16 +697,21 @@ class FiveCardDrawGame(Game):
             self._advance_after_draw(p)
             return
         indices = sorted(p.to_discard)
+        drawn_cards: list[Card] = []
         for idx in reversed(indices):
             if 0 <= idx < len(p.hand):
                 self.discard_pile.append(p.hand.pop(idx))
         for _ in range(len(indices)):
             card = self.deck.draw_one() if self.deck else None
             if card:
+                drawn_cards.append(card)
                 p.hand.append(card)
         p.hand = sort_cards(p.hand)
         self._play_draw_sounds(len(indices))
-        self.broadcast_personal_l(p, "draw-you-draw", "draw-player-draws", count=len(indices))
+        user = self.get_user(p)
+        self.broadcast_l("draw-player-draws", exclude=p, player=p.name, count=len(indices))
+        if user and drawn_cards:
+            user.speak_l("draw-you-drew-cards", cards=read_cards(drawn_cards, user.locale))
         p.to_discard = set()
         self._advance_after_draw(p)
 
@@ -670,17 +725,9 @@ class FiveCardDrawGame(Game):
             return
         if idx < 0 or idx >= len(p.hand):
             return
-        if idx in p.to_discard:
-            p.to_discard.remove(idx)
-        else:
-            max_discards = 4 if any(card.rank == 1 for card in p.hand) else 3
-            if len(p.to_discard) >= max_discards:
-                self.broadcast_personal_l(
-                    p, "draw-you-discard-limit", "draw-player-discard-limit", count=max_discards
-                )
-                return
-            p.to_discard.add(idx)
-        self.rebuild_all_menus()
+        self._set_discard(p, idx, discard=idx not in p.to_discard)
+        self.update_player_menu(p)
+        self._announce_discard_status(p, idx)
 
     # ==========================================================================
     # Action helpers
@@ -730,7 +777,8 @@ class FiveCardDrawGame(Game):
         self.phase = "showdown"
         self.broadcast_l("poker-showdown")
         self._resolve_pots()
-        self._start_new_hand()
+        self._announce_showdown_hands(skip_best=True)
+        self._queue_new_hand()
 
     def _award_uncontested(self, active_ids: set[str]) -> None:
         winner = self.get_player_by_id(next(iter(active_ids))) if active_ids else None
@@ -742,12 +790,12 @@ class FiveCardDrawGame(Game):
         self.play_sound(random.choice(["game_blackjack/win1.ogg", "game_blackjack/win2.ogg", "game_blackjack/win3.ogg"]))
         self.broadcast_l("poker-player-wins-pot", player=winner.name, amount=amount)
         self._sync_team_scores()
-        self._start_new_hand()
+        self._queue_new_hand()
 
     def _resolve_pots(self) -> None:
+        self.last_showdown_winner_ids.clear()
         pots = self.pot_manager.get_pots()
-        single_awards: dict[str, dict[str, object]] = {}
-        for pot in pots:
+        for pot_index, pot in enumerate(pots):
             eligible_players = [self.get_player_by_id(pid) for pid in pot.eligible_player_ids]
             eligible_players = [p for p in eligible_players if isinstance(p, FiveCardDrawPlayer)]
             if not eligible_players:
@@ -763,6 +811,7 @@ class FiveCardDrawGame(Game):
             )
             if not winners or not best_score:
                 continue
+            self.last_showdown_winner_ids.update(w.id for w in winners)
             for w in winners:
                 w.chips += share
             if remainder > 0:
@@ -770,41 +819,73 @@ class FiveCardDrawGame(Game):
             desc = describe_hand(best_score, "en")
             if len(winners) == 1:
                 winner = winners[0]
-                entry = single_awards.get(winner.id)
-                if entry:
-                    entry["amount"] = int(entry["amount"]) + pot.amount
+                cards = read_cards(winner.hand, "en")
+                if pot_index == 0 or len(pot.eligible_player_ids) <= 1:
+                    self.play_sound(random.choice(["game_blackjack/win1.ogg", "game_blackjack/win2.ogg", "game_blackjack/win3.ogg"]))
+                    self.broadcast_l(
+                        "poker-player-wins-pot-hand",
+                        player=winner.name,
+                        amount=pot.amount,
+                        cards=cards,
+                        hand=desc,
+                    )
                 else:
-                    single_awards[winner.id] = {
-                        "name": winner.name,
-                        "amount": pot.amount,
-                        "cards": read_cards(winner.hand, "en"),
-                        "hand": desc,
-                    }
+                    self.play_sound(random.choice(["game_blackjack/win1.ogg", "game_blackjack/win2.ogg", "game_blackjack/win3.ogg"]))
+                    self.broadcast_l(
+                        "poker-player-wins-side-pot-hand",
+                        player=winner.name,
+                        amount=pot.amount,
+                        index=pot_index,
+                        cards=cards,
+                        hand=desc,
+                    )
             else:
                 names = ", ".join(w.name for w in winners)
                 self.play_sound(random.choice(["game_blackjack/win1.ogg", "game_blackjack/win2.ogg", "game_blackjack/win3.ogg"]))
-                self.broadcast_l("poker-players-split-pot", players=names, amount=pot.amount, hand=desc)
-        if single_awards:
-            ordered_ids = order_after_button(
-                [p.id for p in self.get_active_players()],
-                self.table_state.get_button_id([p.id for p in self.get_active_players()]),
-            )
-            for winner_id in sorted(
-                single_awards.keys(),
-                key=lambda pid: ordered_ids.index(pid) if pid in ordered_ids else len(ordered_ids),
-            ):
-                entry = single_awards[winner_id]
-                self.play_sound(
-                    random.choice(["game_blackjack/win1.ogg", "game_blackjack/win2.ogg", "game_blackjack/win3.ogg"])
-                )
-                self.broadcast_l(
-                    "poker-player-wins-pot-hand",
-                    player=entry["name"],
-                    amount=entry["amount"],
-                    cards=entry["cards"],
-                    hand=entry["hand"],
-                )
+                if pot_index == 0:
+                    self.broadcast_l("poker-players-split-pot", players=names, amount=pot.amount, hand=desc)
+                else:
+                    self.broadcast_l(
+                        "poker-players-split-side-pot",
+                        players=names,
+                        amount=pot.amount,
+                        index=pot_index,
+                        hand=desc,
+                    )
         self._sync_team_scores()
+
+    def _announce_showdown_hands(self, skip_best: bool = False) -> None:
+        active = [p for p in self.get_active_players() if isinstance(p, FiveCardDrawPlayer) and not p.folded]
+        if len(active) <= 1:
+            return
+        skip_ids: set[str] = set()
+        if skip_best and self.last_showdown_winner_ids:
+            skip_ids = set(self.last_showdown_winner_ids)
+        active_ids = [p.id for p in active]
+        lines = format_showdown_lines(
+            active,
+            active_ids,
+            self.table_state.get_button_id(active_ids),
+            lambda p: p.id,
+            lambda p: (
+                (
+                    "poker-show-hand",
+                    {
+                        "player": p.name,
+                        "cards": read_cards(p.hand, "en"),
+                        "hand": describe_hand(best_hand(p.hand)[0], "en"),
+                    },
+                ),
+                best_hand(p.hand)[0],
+            ),
+        )
+        for player_id, (message_id, kwargs), _score in lines:
+            if skip_ids and player_id in skip_ids:
+                continue
+            self.broadcast_l(message_id, **kwargs)
+
+    def _queue_new_hand(self) -> None:
+        self._next_hand_wait_ticks = 100
 
     def _order_winners_by_button(self, winners: list[FiveCardDrawPlayer]) -> list[FiveCardDrawPlayer]:
         if len(winners) <= 1:
@@ -966,6 +1047,16 @@ class FiveCardDrawGame(Game):
             return Visibility.HIDDEN
         return self._is_turn_action_hidden(player)
 
+    def _is_bet_action_enabled(self, player: Player) -> str | None:
+        if self.phase == "draw":
+            return "draw-not-betting"
+        return self._is_turn_action_enabled(player)
+
+    def _is_bet_action_hidden(self, player: Player) -> Visibility:
+        if self.phase == "draw":
+            return Visibility.HIDDEN
+        return self._is_turn_action_hidden(player)
+
     def _is_discard_toggle_enabled(self, player: Player) -> str | None:
         if self.phase != "draw":
             return "action-not-playing"
@@ -975,6 +1066,111 @@ class FiveCardDrawGame(Game):
         if self.phase != "draw":
             return Visibility.HIDDEN
         return self._is_turn_action_hidden(player)
+
+    def _action_read_card(self, player: Player, action_id: str) -> None:
+        p = player if isinstance(player, FiveCardDrawPlayer) else None
+        if not p:
+            return
+        try:
+            idx = int(action_id.split("_")[-1]) - 1
+        except ValueError:
+            return
+        if idx < 0 or idx >= len(p.hand):
+            return
+        user = self.get_user(player)
+        if user:
+            user.speak(card_name(p.hand[idx], user.locale))
+
+    def _get_toggle_discard_label(self, player: Player, action_id: str) -> str:
+        p = player if isinstance(player, FiveCardDrawPlayer) else None
+        if not p:
+            return action_id
+        try:
+            idx = int(action_id.split("_")[-1]) - 1
+        except ValueError:
+            return action_id
+        if idx < 0 or idx >= len(p.hand):
+            return action_id
+        user = self.get_user(player)
+        locale = user.locale if user else "en"
+        name = card_name(p.hand[idx], locale)
+        if idx in p.to_discard:
+            return Localization.get(locale, "draw-card-discard", card=name)
+        style = user.preferences.dice_keeping_style if user else DiceKeepingStyle.PLAYPALACE
+        if style == DiceKeepingStyle.QUENTIN_C:
+            return name
+        return Localization.get(locale, "draw-card-keep", card=name)
+
+    def _get_draw_label(self, player: Player, action_id: str) -> str:
+        p = player if isinstance(player, FiveCardDrawPlayer) else None
+        if not p:
+            return Localization.get("en", "draw-draw-cards")
+        count = len(p.to_discard)
+        user = self.get_user(player)
+        locale = user.locale if user else "en"
+        return Localization.get(locale, "draw-draw-cards-count", count=count)
+
+    def _set_discard(self, player: FiveCardDrawPlayer, idx: int, discard: bool) -> None:
+        if discard:
+            max_discards = 4 if any(card.rank == 1 for card in player.hand) else 3
+            if len(player.to_discard) >= max_discards and idx not in player.to_discard:
+                self.broadcast_personal_l(
+                    player, "draw-you-discard-limit", "draw-player-discard-limit", count=max_discards
+                )
+                return
+            player.to_discard.add(idx)
+        else:
+            player.to_discard.discard(idx)
+
+    def _announce_discard_status(self, player: FiveCardDrawPlayer, idx: int) -> None:
+        user = self.get_user(player)
+        if not user:
+            return
+        if idx < 0 or idx >= len(player.hand):
+            return
+        card = card_name(player.hand[idx], user.locale)
+        if idx in player.to_discard:
+            user.speak_l("draw-card-discarded", card=card)
+        else:
+            user.speak_l("draw-card-kept", card=card)
+
+    def _action_card_key(self, player: Player, action_id: str) -> None:
+        p = self._require_active_player(player)
+        if not p or self.phase != "draw":
+            return
+        try:
+            idx = int(action_id.split("_")[-1]) - 1
+        except ValueError:
+            return
+        if idx < 0 or idx >= len(p.hand):
+            return
+        user = self.get_user(player)
+        style = user.preferences.dice_keeping_style if user else DiceKeepingStyle.PLAYPALACE
+        if style == DiceKeepingStyle.QUENTIN_C:
+            self._set_discard(p, idx, discard=False)
+        else:
+            self._set_discard(p, idx, discard=idx not in p.to_discard)
+        self.update_player_menu(p)
+        self._announce_discard_status(p, idx)
+
+    def _action_card_discard(self, player: Player, action_id: str) -> None:
+        p = self._require_active_player(player)
+        if not p or self.phase != "draw":
+            return
+        try:
+            idx = int(action_id.split("_")[-1]) - 1
+        except ValueError:
+            return
+        if idx < 0 or idx >= len(p.hand):
+            return
+        user = self.get_user(player)
+        style = user.preferences.dice_keeping_style if user else DiceKeepingStyle.PLAYPALACE
+        if style == DiceKeepingStyle.QUENTIN_C:
+            self._set_discard(p, idx, discard=True)
+        else:
+            self._set_discard(p, idx, discard=idx not in p.to_discard)
+        self.update_player_menu(p)
+        self._announce_discard_status(p, idx)
 
     def _is_check_enabled(self, player: Player) -> str | None:
         if self.status != "playing":
@@ -1011,6 +1207,7 @@ class FiveCardDrawGame(Game):
     def build_game_result(self) -> GameResult:
         active = self.get_active_players()
         winner = max(active, key=lambda p: p.chips, default=None)
+        final_chips = {p.name: p.chips for p in active}
         return GameResult(
             game_type=self.get_type(),
             timestamp=datetime.now().isoformat(),
@@ -1026,11 +1223,20 @@ class FiveCardDrawGame(Game):
             custom_data={
                 "winner_name": winner.name if winner else None,
                 "winner_chips": winner.chips if winner else 0,
+                "final_chips": final_chips,
             },
         )
 
     def _end_game(self, winner: FiveCardDrawPlayer | None) -> None:
-        self.play_sound(random.choice(["game_blackjack/win1.ogg", "game_blackjack/win2.ogg"]))
+        self.play_sound("game_pig/win.ogg")
         if winner:
             self.broadcast_l("poker-player-wins-game", player=winner.name)
         self.finish_game()
+
+    def format_end_screen(self, result: GameResult, locale: str) -> list[str]:
+        lines = [Localization.get(locale, "game-final-scores")]
+        final_chips = result.custom_data.get("final_chips", {})
+        sorted_scores = sorted(final_chips.items(), key=lambda item: item[1], reverse=True)
+        for i, (name, chips) in enumerate(sorted_scores, 1):
+            lines.append(f"{i}. {name}: {chips} chips")
+        return lines

--- a/server/games/holdem/game.py
+++ b/server/games/holdem/game.py
@@ -753,6 +753,8 @@ class HoldemGame(Game):
             self.play_sound("game_3cardpoker/bet.ogg")
             poker_log.log_call(self.action_log, p.name, pay)
             self.broadcast_l("poker-player-calls", player=p.name, amount=pay)
+        if p.all_in and pay > 0:
+            self.broadcast_l("poker-player-all-in", player=p.name, amount=pay)
         self._sync_team_scores()
         self._after_action()
 
@@ -798,6 +800,8 @@ class HoldemGame(Game):
         self.betting.record_bet(p.id, total, is_raise=True)
         poker_log.log_raise(self.action_log, p.name, total)
         self.broadcast_l("poker-player-raises", player=p.name, amount=total)
+        if p.all_in:
+            self.broadcast_l("poker-player-all-in", player=p.name, amount=total)
         self._sync_team_scores()
         self._after_action()
 
@@ -840,6 +844,8 @@ class HoldemGame(Game):
         else:
             poker_log.log_call(self.action_log, p.name, pay)
             self.broadcast_l("poker-player-calls", player=p.name, amount=pay)
+        if p.all_in:
+            self.broadcast_l("poker-player-all-in", player=p.name, amount=pay)
         self._sync_team_scores()
         self._after_action()
 
@@ -904,8 +910,7 @@ class HoldemGame(Game):
     def _resolve_pots(self) -> None:
         self.last_showdown_winner_ids.clear()
         pots = self.pot_manager.get_pots()
-        single_awards: dict[str, dict[str, object]] = {}
-        for pot in pots:
+        for pot_index, pot in enumerate(pots):
             eligible_players = [self.get_player_by_id(pid) for pid in pot.eligible_player_ids]
             eligible_players = [p for p in eligible_players if isinstance(p, HoldemPlayer)]
             if not eligible_players:
@@ -929,40 +934,39 @@ class HoldemGame(Game):
             desc = describe_hand(best_score, "en")
             if len(winners) == 1:
                 winner = winners[0]
-                entry = single_awards.get(winner.id)
-                if entry:
-                    entry["amount"] = int(entry["amount"]) + pot.amount
+                cards = read_cards(winner.hand, "en")
+                if pot_index == 0 or len(pot.eligible_player_ids) <= 1:
+                    self.play_sound(random.choice(["game_blackjack/win1.ogg", "game_blackjack/win2.ogg", "game_blackjack/win3.ogg"]))
+                    self.broadcast_l(
+                        "poker-player-wins-pot-hand",
+                        player=winner.name,
+                        amount=pot.amount,
+                        cards=cards,
+                        hand=desc,
+                    )
                 else:
-                    single_awards[winner.id] = {
-                        "name": winner.name,
-                        "amount": pot.amount,
-                        "cards": read_cards(winner.hand, "en"),
-                        "hand": desc,
-                    }
+                    self.play_sound(random.choice(["game_blackjack/win1.ogg", "game_blackjack/win2.ogg", "game_blackjack/win3.ogg"]))
+                    self.broadcast_l(
+                        "poker-player-wins-side-pot-hand",
+                        player=winner.name,
+                        amount=pot.amount,
+                        index=pot_index,
+                        cards=cards,
+                        hand=desc,
+                    )
             else:
                 names = ", ".join(w.name for w in winners)
                 self.play_sound(random.choice(["game_blackjack/win1.ogg", "game_blackjack/win2.ogg", "game_blackjack/win3.ogg"]))
-                self.broadcast_l("poker-players-split-pot", players=names, amount=pot.amount, hand=desc)
-        if single_awards:
-            ordered_ids = order_after_button(
-                [p.id for p in self.get_active_players()],
-                self.table_state.get_button_id([p.id for p in self.get_active_players()]),
-            )
-            for winner_id in sorted(
-                single_awards.keys(),
-                key=lambda pid: ordered_ids.index(pid) if pid in ordered_ids else len(ordered_ids),
-            ):
-                entry = single_awards[winner_id]
-                self.play_sound(
-                    random.choice(["game_blackjack/win1.ogg", "game_blackjack/win2.ogg", "game_blackjack/win3.ogg"])
-                )
-                self.broadcast_l(
-                    "poker-player-wins-pot-hand",
-                    player=entry["name"],
-                    amount=entry["amount"],
-                    cards=entry["cards"],
-                    hand=entry["hand"],
-                )
+                if pot_index == 0:
+                    self.broadcast_l("poker-players-split-pot", players=names, amount=pot.amount, hand=desc)
+                else:
+                    self.broadcast_l(
+                        "poker-players-split-side-pot",
+                        players=names,
+                        amount=pot.amount,
+                        index=pot_index,
+                        hand=desc,
+                    )
         self._sync_team_scores()
 
     def _announce_showdown_hands(self, skip_best: bool = False) -> None:
@@ -970,7 +974,7 @@ class HoldemGame(Game):
         if len(active) <= 1:
             return
         skip_ids: set[str] = set()
-        if skip_best and len(self.last_showdown_winner_ids) == 1:
+        if skip_best and self.last_showdown_winner_ids:
             skip_ids = set(self.last_showdown_winner_ids)
         active_ids = [p.id for p in active]
         lines = format_showdown_lines(
@@ -1251,10 +1255,7 @@ class HoldemGame(Game):
         player = self.current_player
         if not isinstance(player, HoldemPlayer):
             return
-        if self.betting and self.betting.amount_to_call(player.id) > 0:
-            self._action_fold(player, "fold")
-        else:
-            self._action_call(player, "call")
+        self._action_fold(player, "fold")
 
     def _sync_team_scores(self) -> None:
         for team in self._team_manager.teams:
@@ -1267,6 +1268,7 @@ class HoldemGame(Game):
     def build_game_result(self) -> GameResult:
         active = self.get_active_players()
         winner = max(active, key=lambda p: p.chips, default=None)
+        final_chips = {p.name: p.chips for p in active}
         return GameResult(
             game_type=self.get_type(),
             timestamp=datetime.now().isoformat(),
@@ -1282,11 +1284,20 @@ class HoldemGame(Game):
             custom_data={
                 "winner_name": winner.name if winner else None,
                 "winner_chips": winner.chips if winner else 0,
+                "final_chips": final_chips,
             },
         )
 
     def _end_game(self, winner: HoldemPlayer | None) -> None:
-        self.play_sound(random.choice(["game_blackjack/win1.ogg", "game_blackjack/win2.ogg"]))
+        self.play_sound("game_pig/win.ogg")
         if winner:
             self.broadcast_l("poker-player-wins-game", player=winner.name)
         self.finish_game()
+
+    def format_end_screen(self, result: GameResult, locale: str) -> list[str]:
+        lines = [Localization.get(locale, "game-final-scores")]
+        final_chips = result.custom_data.get("final_chips", {})
+        sorted_scores = sorted(final_chips.items(), key=lambda item: item[1], reverse=True)
+        for i, (name, chips) in enumerate(sorted_scores, 1):
+            lines.append(f"{i}. {name}: {chips} chips")
+        return lines

--- a/server/locales/en/fivecarddraw.ftl
+++ b/server/locales/en/fivecarddraw.ftl
@@ -23,14 +23,31 @@ draw-enter-max-raises = Enter max raises (0 for unlimited)
 draw-option-changed-max-raises = Max raises set to { $count }.
 
 draw-antes-posted = Antes posted: { $amount }.
-draw-betting-round-1 = Betting round 1.
-draw-betting-round-2 = Betting round 2.
+draw-betting-round-1 = Betting round.
+draw-betting-round-2 = Betting round.
 draw-begin-draw = Draw phase.
+draw-not-betting = You cannot bet during the draw phase.
 
 draw-toggle-discard = Toggle discard for card { $index }
+draw-card-keep = { $card }
+draw-card-discard = Discard { $card }
+draw-card-kept = Keep { $card }.
+draw-card-discarded = Discard { $card }.
 draw-draw-cards = Draw cards
-draw-you-draw = You draw { $count } cards.
-draw-player-draws = { $player } draws { $count } cards.
+draw-draw-cards-count = Draw { $count } { $count ->
+    [one] card
+   *[other] cards
+}
+draw-dealt-cards = You are dealt { $cards }.
+draw-you-drew-cards = You draw { $cards }.
+draw-you-draw = You draw { $count } { $count ->
+    [one] card
+   *[other] cards
+}.
+draw-player-draws = { $player } draws { $count } { $count ->
+    [one] card
+   *[other] cards
+}.
 draw-you-stand-pat = You stand pat.
 draw-player-stands-pat = { $player } stands pat.
 draw-you-discard-limit = You may discard up to { $count } cards.

--- a/server/locales/en/poker.ftl
+++ b/server/locales/en/poker.ftl
@@ -41,7 +41,10 @@ poker-player-all-in = { $player } goes all in for { $amount } chips.
 
 poker-player-wins-pot = { $player } wins { $amount } chips.
 poker-player-wins-pot-hand = { $player } wins { $amount } chips with { $cards } for { $hand }.
+poker-player-wins-side-pot-hand = { $player } wins side pot { $index } of { $amount } chips with { $cards } for { $hand }.
 poker-players-split-pot = { $players } split { $amount } chips with { $hand }.
+poker-players-split-side-pot = { $players } split side pot { $index } of { $amount } chips with { $hand }.
+poker-player-all-in = { $player } goes all in for { $amount } chips.
 poker-player-wins-game = { $player } wins the game.
 
 poker-showdown = Showdown.

--- a/server/locales/pl/fivecarddraw.ftl
+++ b/server/locales/pl/fivecarddraw.ftl
@@ -23,14 +23,31 @@ draw-enter-max-raises = Enter max raises (0 for unlimited)
 draw-option-changed-max-raises = Max raises set to { $count }.
 
 draw-antes-posted = Antes posted: { $amount }.
-draw-betting-round-1 = Betting round 1.
-draw-betting-round-2 = Betting round 2.
+draw-betting-round-1 = Betting round.
+draw-betting-round-2 = Betting round.
 draw-begin-draw = Draw phase.
+draw-not-betting = Nie możesz licytować podczas wymiany kart.
 
 draw-toggle-discard = Toggle discard for card { $index }
+draw-card-keep = { $card }
+draw-card-discard = Odrzuć { $card }
+draw-card-kept = Zachowaj { $card }.
+draw-card-discarded = Odrzuć { $card }.
 draw-draw-cards = Draw cards
-draw-you-draw = You draw { $count } cards.
-draw-player-draws = { $player } draws { $count } cards.
+draw-draw-cards-count = Draw { $count } { $count ->
+    [one] card
+   *[other] cards
+}
+draw-dealt-cards = You are dealt { $cards }.
+draw-you-drew-cards = Dobierasz { $cards }.
+draw-you-draw = You draw { $count } { $count ->
+    [one] card
+   *[other] cards
+}.
+draw-player-draws = { $player } draws { $count } { $count ->
+    [one] card
+   *[other] cards
+}.
 draw-you-stand-pat = You stand pat.
 draw-player-stands-pat = { $player } stands pat.
 draw-you-discard-limit = You may discard up to { $count } cards.

--- a/server/locales/pl/poker.ftl
+++ b/server/locales/pl/poker.ftl
@@ -41,7 +41,10 @@ poker-player-all-in = { $player } goes all in for { $amount } chips.
 
 poker-player-wins-pot = { $player } wins { $amount } chips.
 poker-player-wins-pot-hand = { $player } wins { $amount } chips with { $cards } for { $hand }.
+poker-player-wins-side-pot-hand = { $player } wins side pot { $index } of { $amount } chips with { $cards } for { $hand }.
 poker-players-split-pot = { $players } split { $amount } chips with { $hand }.
+poker-players-split-side-pot = { $players } split side pot { $index } of { $amount } chips with { $hand }.
+poker-player-all-in = { $player } goes all in for { $amount } chips.
 poker-player-wins-game = { $player } wins the game.
 
 poker-showdown = Showdown.

--- a/server/locales/pt/fivecarddraw.ftl
+++ b/server/locales/pt/fivecarddraw.ftl
@@ -23,14 +23,31 @@ draw-enter-max-raises = Enter max raises (0 for unlimited)
 draw-option-changed-max-raises = Max raises set to { $count }.
 
 draw-antes-posted = Antes posted: { $amount }.
-draw-betting-round-1 = Betting round 1.
-draw-betting-round-2 = Betting round 2.
+draw-betting-round-1 = Betting round.
+draw-betting-round-2 = Betting round.
 draw-begin-draw = Draw phase.
+draw-not-betting = Você não pode apostar durante a fase de troca.
 
 draw-toggle-discard = Toggle discard for card { $index }
+draw-card-keep = { $card }
+draw-card-discard = Descartar { $card }
+draw-card-kept = Manter { $card }.
+draw-card-discarded = Descartar { $card }.
 draw-draw-cards = Draw cards
-draw-you-draw = You draw { $count } cards.
-draw-player-draws = { $player } draws { $count } cards.
+draw-draw-cards-count = Draw { $count } { $count ->
+    [one] card
+   *[other] cards
+}
+draw-dealt-cards = You are dealt { $cards }.
+draw-you-drew-cards = Você compra { $cards }.
+draw-you-draw = You draw { $count } { $count ->
+    [one] card
+   *[other] cards
+}.
+draw-player-draws = { $player } draws { $count } { $count ->
+    [one] card
+   *[other] cards
+}.
 draw-you-stand-pat = You stand pat.
 draw-player-stands-pat = { $player } stands pat.
 draw-you-discard-limit = You may discard up to { $count } cards.

--- a/server/locales/pt/poker.ftl
+++ b/server/locales/pt/poker.ftl
@@ -41,7 +41,10 @@ poker-player-all-in = { $player } goes all in for { $amount } chips.
 
 poker-player-wins-pot = { $player } wins { $amount } chips.
 poker-player-wins-pot-hand = { $player } wins { $amount } chips with { $cards } for { $hand }.
+poker-player-wins-side-pot-hand = { $player } wins side pot { $index } of { $amount } chips with { $cards } for { $hand }.
 poker-players-split-pot = { $players } split { $amount } chips with { $hand }.
+poker-players-split-side-pot = { $players } split side pot { $index } of { $amount } chips with { $hand }.
+poker-player-all-in = { $player } goes all in for { $amount } chips.
 poker-player-wins-game = { $player } wins the game.
 
 poker-showdown = Showdown.

--- a/server/locales/zh/fivecarddraw.ftl
+++ b/server/locales/zh/fivecarddraw.ftl
@@ -23,14 +23,31 @@ draw-enter-max-raises = Enter max raises (0 for unlimited)
 draw-option-changed-max-raises = Max raises set to { $count }.
 
 draw-antes-posted = Antes posted: { $amount }.
-draw-betting-round-1 = Betting round 1.
-draw-betting-round-2 = Betting round 2.
+draw-betting-round-1 = Betting round.
+draw-betting-round-2 = Betting round.
 draw-begin-draw = Draw phase.
+draw-not-betting = 抽牌阶段不能下注。
 
 draw-toggle-discard = Toggle discard for card { $index }
+draw-card-keep = { $card }
+draw-card-discard = 弃掉{ $card }
+draw-card-kept = 保留{ $card }。
+draw-card-discarded = 弃掉{ $card }。
 draw-draw-cards = Draw cards
-draw-you-draw = You draw { $count } cards.
-draw-player-draws = { $player } draws { $count } cards.
+draw-draw-cards-count = Draw { $count } { $count ->
+    [one] card
+   *[other] cards
+}
+draw-dealt-cards = You are dealt { $cards }.
+draw-you-drew-cards = 你抽到{ $cards }。
+draw-you-draw = You draw { $count } { $count ->
+    [one] card
+   *[other] cards
+}.
+draw-player-draws = { $player } draws { $count } { $count ->
+    [one] card
+   *[other] cards
+}.
 draw-you-stand-pat = You stand pat.
 draw-player-stands-pat = { $player } stands pat.
 draw-you-discard-limit = You may discard up to { $count } cards.

--- a/server/locales/zh/poker.ftl
+++ b/server/locales/zh/poker.ftl
@@ -41,7 +41,10 @@ poker-player-all-in = { $player } goes all in for { $amount } chips.
 
 poker-player-wins-pot = { $player } wins { $amount } chips.
 poker-player-wins-pot-hand = { $player } wins { $amount } chips with { $cards } for { $hand }.
+poker-player-wins-side-pot-hand = { $player } wins side pot { $index } of { $amount } chips with { $cards } for { $hand }.
 poker-players-split-pot = { $players } split { $amount } chips with { $hand }.
+poker-players-split-side-pot = { $players } split side pot { $index } of { $amount } chips with { $hand }.
+poker-player-all-in = { $player } goes all in for { $amount } chips.
 poker-player-wins-game = { $player } wins the game.
 
 poker-showdown = Showdown.


### PR DESCRIPTION
## Summary
  - Align Five Card Draw with Hold’em pacing and showdown behavior.
  - Improve draw-phase UX: toggle discard/keep by style, dynamic draw count label, and clean
  draw announcements.
  - Add all-in announcements and side-pot phrasing improvements.
  - Add localized strings for new draw/poker messages.

  ## Details
  - Draw phase hides betting actions and uses keep/discard semantics (PlayPalace vs Quentin).
  - Draw action now announces only drawn cards for the active player.
  - Side pots announce as normal wins when only one player is eligible.
  - Final chips are sorted high-to-low on the end screen.
