### PR TITLE
Add Vietnamese translations

### DIFF
--- a/server/locales/vi/ageofheroes.ftl
+++ b/server/locales/vi/ageofheroes.ftl
@@ -1,0 +1,434 @@
+# Thông báo trò chơi Age of Heroes
+# Trò chơi bài xây dựng nền văn minh dành cho 2-6 người chơi
+
+# Tên trò chơi
+game-name-ageofheroes = Kỷ Nguyên Anh Hùng
+
+# Các bộ tộc
+ageofheroes-tribe-egyptians = Ai Cập
+ageofheroes-tribe-romans = La Mã
+ageofheroes-tribe-greeks = Hy Lạp
+ageofheroes-tribe-babylonians = Babylon
+ageofheroes-tribe-celts = Celt
+ageofheroes-tribe-chinese = Trung Hoa
+
+# Tài nguyên đặc biệt (để xây kỳ quan)
+ageofheroes-special-limestone = Đá vôi
+ageofheroes-special-concrete = Bê tông
+ageofheroes-special-marble = Cẩm thạch
+ageofheroes-special-bricks = Gạch
+ageofheroes-special-sandstone = Đá sa thạch
+ageofheroes-special-granite = Đá hoa cương
+
+# Tài nguyên cơ bản
+ageofheroes-resource-iron = Sắt
+ageofheroes-resource-wood = Gỗ
+ageofheroes-resource-grain = Ngũ cốc
+ageofheroes-resource-stone = Đá
+ageofheroes-resource-gold = Vàng
+
+# Sự kiện
+ageofheroes-event-population-growth = Gia tăng dân số
+ageofheroes-event-earthquake = Động đất
+ageofheroes-event-eruption = Núi lửa phun trào
+ageofheroes-event-hunger = Nạn đói
+ageofheroes-event-barbarians = Man tộc xâm lược
+ageofheroes-event-olympics = Thế vận hội Olympic
+ageofheroes-event-hero = Anh hùng
+ageofheroes-event-fortune = Vận may
+
+# Công trình/Đơn vị
+ageofheroes-building-army = Quân đội
+ageofheroes-building-fortress = Pháo đài
+ageofheroes-building-general = Tướng lĩnh
+ageofheroes-building-road = Đường xá
+ageofheroes-building-city = Thành phố
+
+# Hành động
+ageofheroes-action-tax-collection = Thu thuế
+ageofheroes-action-construction = Xây dựng
+ageofheroes-action-war = Chiến tranh
+ageofheroes-action-do-nothing = Không làm gì
+ageofheroes-play = Chơi
+
+# Mục tiêu chiến tranh
+ageofheroes-war-conquest = Chinh phục
+ageofheroes-war-plunder = Cướp bóc
+ageofheroes-war-destruction = Phá hủy
+
+# Tùy chọn game
+ageofheroes-set-victory-cities = Số thành phố để thắng: { $cities }
+ageofheroes-enter-victory-cities = Nhập số thành phố cần để thắng (3-7)
+ageofheroes-set-victory-monument = Tiến độ kỳ quan để thắng: { $progress }%
+ageofheroes-toggle-neighbor-roads = Chỉ làm đường tới hàng xóm: { $enabled }
+ageofheroes-set-max-hand = Số bài tối đa trên tay: { $cards } lá
+
+# Thông báo thay đổi tùy chọn
+ageofheroes-option-changed-victory-cities = Điều kiện thắng: cần { $cities } thành phố.
+ageofheroes-option-changed-victory-monument = Điều kiện thắng: hoàn thành { $progress }% kỳ quan.
+ageofheroes-option-changed-neighbor-roads = Chỉ làm đường tới hàng xóm: { $enabled }.
+ageofheroes-option-changed-max-hand = Số bài tối đa trên tay đã đặt là { $cards } lá.
+
+# Giai đoạn Thiết lập
+ageofheroes-setup-start = Bạn là thủ lĩnh của bộ tộc { $tribe }. Tài nguyên kỳ quan đặc biệt của bạn là { $special }. Gieo xúc xắc để xác định thứ tự đi.
+ageofheroes-setup-viewer = Các người chơi đang gieo xúc xắc chọn thứ tự.
+ageofheroes-roll-dice = Gieo xúc xắc
+ageofheroes-war-roll-dice = Gieo xúc xắc
+ageofheroes-dice-result = Bạn gieo được { $total } ({ $die1 } + { $die2 }).
+ageofheroes-dice-result-other = { $player } gieo được { $total }.
+ageofheroes-dice-tie = Nhiều người chơi bằng điểm ({ $total }). Đang gieo lại...
+ageofheroes-first-player = { $player } gieo cao nhất ({ $total }) và đi trước.
+ageofheroes-first-player-you = Với { $total } điểm, bạn được đi trước.
+
+# Giai đoạn Chuẩn bị
+ageofheroes-prepare-start = Người chơi phải đánh bài sự kiện và bỏ bài thảm họa.
+ageofheroes-prepare-your-turn = Bạn có { $count } { $count ->
+    [one] lá bài
+   *[other] lá bài
+} cần đánh hoặc bỏ.
+ageofheroes-prepare-done = Hoàn tất giai đoạn chuẩn bị.
+
+# Đánh/Bỏ sự kiện
+ageofheroes-population-growth = { $player } dùng Gia tăng dân số và xây thêm một thành phố.
+ageofheroes-population-growth-you = Bạn dùng Gia tăng dân số và xây thêm một thành phố.
+ageofheroes-discard-card = { $player } bỏ lá { $card }.
+ageofheroes-discard-card-you = Bạn bỏ lá { $card }.
+ageofheroes-earthquake = Động đất tấn công bộ tộc của { $player }; quân đội phải lui về hồi phục.
+ageofheroes-earthquake-you = Động đất tấn công bộ tộc của bạn; quân đội phải lui về hồi phục.
+ageofheroes-eruption = Núi lửa phun trào phá hủy một thành phố của { $player }.
+ageofheroes-eruption-you = Núi lửa phun trào phá hủy một thành phố của bạn.
+
+# Hiệu ứng thảm họa
+ageofheroes-hunger-strikes = Nạn đói ập đến.
+ageofheroes-lose-card-hunger = Bạn mất lá { $card }.
+ageofheroes-barbarians-pillage = Man tộc tấn công kho tài nguyên của { $player }.
+ageofheroes-barbarians-attack = Man tộc tấn công kho tài nguyên của { $player }.
+ageofheroes-barbarians-attack-you = Man tộc tấn công kho tài nguyên của bạn.
+ageofheroes-lose-card-barbarians = Bạn mất lá { $card }.
+ageofheroes-block-with-card = { $player } chặn thảm họa bằng lá { $card }.
+ageofheroes-block-with-card-you = Bạn chặn thảm họa bằng lá { $card }.
+
+# Bài thảm họa có mục tiêu (Động đất/Núi lửa)
+ageofheroes-select-disaster-target = Chọn mục tiêu cho lá { $card }.
+ageofheroes-no-targets = Không có mục tiêu hợp lệ.
+ageofheroes-earthquake-strikes-you = { $attacker } dùng Động đất tấn công bạn. Quân đội của bạn bị vô hiệu hóa.
+ageofheroes-earthquake-strikes = { $attacker } dùng Động đất tấn công { $player }.
+ageofheroes-armies-disabled = { $count } { $count ->
+    [one] quân đoàn bị
+   *[other] quân đoàn bị
+} vô hiệu hóa trong một lượt.
+ageofheroes-eruption-strikes-you = { $attacker } dùng Núi lửa tấn công bạn. Một thành phố của bạn bị phá hủy.
+ageofheroes-eruption-strikes = { $attacker } dùng Núi lửa tấn công { $player }.
+ageofheroes-city-destroyed = Một thành phố đã bị phá hủy do núi lửa.
+
+# Giai đoạn Chợ phiên
+ageofheroes-fair-start = Một ngày mới bắt đầu tại khu chợ.
+ageofheroes-fair-draw-base = Bạn rút { $count } { $count ->
+    [one] lá bài
+   *[other] lá bài
+}.
+ageofheroes-fair-draw-roads = Bạn rút thêm { $count } { $count ->
+    [one] lá bài
+   *[other] lá bài
+} nhờ mạng lưới đường xá.
+ageofheroes-fair-draw-other = { $player } rút { $count } { $count ->
+    [one] lá bài
+   *[other] lá bài
+}.
+
+# Giao dịch/Đấu giá
+ageofheroes-auction-start = Bắt đầu đấu giá.
+ageofheroes-offer-trade = Đề nghị trao đổi
+ageofheroes-offer-made = { $player } đề nghị đổi { $card } lấy { $wanted }.
+ageofheroes-offer-made-you = Bạn đề nghị đổi { $card } lấy { $wanted }.
+ageofheroes-trade-accepted = { $player } chấp nhận lời đề nghị của { $other } và đổi { $give } lấy { $receive }.
+ageofheroes-trade-accepted-you = Bạn chấp nhận lời đề nghị của { $other } và nhận được { $receive }.
+ageofheroes-trade-cancelled = { $player } rút lại lời đề nghị cho lá { $card }.
+ageofheroes-trade-cancelled-you = Bạn rút lại lời đề nghị cho lá { $card }.
+ageofheroes-stop-trading = Dừng giao dịch
+ageofheroes-select-request = Bạn đang mời đổi lá { $card }. Bạn muốn nhận lại gì?
+ageofheroes-cancel = Hủy
+ageofheroes-left-auction = { $player } rời phiên chợ.
+ageofheroes-left-auction-you = Bạn rời phiên chợ.
+ageofheroes-any-card = Bất kỳ lá nào
+ageofheroes-cannot-trade-own-special = Bạn không thể giao dịch tài nguyên kỳ quan riêng của mình.
+ageofheroes-resource-not-in-game = Tài nguyên đặc biệt này không được sử dụng trong ván này.
+
+# Giai đoạn Chơi chính
+ageofheroes-play-start = Giai đoạn Chơi.
+ageofheroes-day = Ngày { $day }
+ageofheroes-draw-card = { $player } rút một lá từ bộ bài.
+ageofheroes-draw-card-you = Bạn rút lá { $card } từ bộ bài.
+ageofheroes-your-action = Bạn muốn làm gì?
+
+# Thu thuế
+ageofheroes-tax-collection = { $player } chọn Thu thuế: { $cities } { $cities ->
+    [one] thành phố
+   *[other] thành phố
+} thu được { $cards } { $cards ->
+    [one] lá bài
+   *[other] lá bài
+}.
+ageofheroes-tax-collection-you = Bạn chọn Thu thuế: { $cities } { $cities ->
+    [one] thành phố
+   *[other] thành phố
+} thu được { $cards } { $cards ->
+    [one] lá bài
+   *[other] lá bài
+}.
+ageofheroes-tax-no-city = Thu thuế: Bạn không còn thành phố nào. Hãy bỏ một lá để rút lá mới.
+ageofheroes-tax-no-city-done = { $player } chọn Thu thuế nhưng không có thành phố, nên đổi một lá bài.
+ageofheroes-tax-no-city-done-you = Thu thuế: Bạn đã đổi lá { $card } lấy một lá mới.
+
+# Xây dựng
+ageofheroes-construction-menu = Bạn muốn xây gì?
+ageofheroes-construction-done = { $player } đã xây { $article } { $building }.
+ageofheroes-construction-done-you = Bạn đã xây { $article } { $building }.
+ageofheroes-construction-stop = Dừng xây dựng
+ageofheroes-construction-stopped = Bạn đã quyết định dừng xây.
+ageofheroes-road-select-neighbor = Chọn hàng xóm để làm đường tới.
+ageofheroes-direction-left = Bên trái bạn
+ageofheroes-direction-right = Bên phải bạn
+ageofheroes-road-request-sent = Đã gửi yêu cầu làm đường. Đang chờ hàng xóm chấp thuận.
+ageofheroes-road-request-received = { $requester } xin phép làm đường tới bộ tộc của bạn.
+ageofheroes-road-request-denied-you = Bạn đã từ chối yêu cầu làm đường.
+ageofheroes-road-request-denied = { $denier } đã từ chối yêu cầu làm đường của bạn.
+ageofheroes-road-built = { $tribe1 } và { $tribe2 } giờ đã được nối liền bằng đường bộ.
+ageofheroes-road-no-target = Không có bộ tộc lân cận nào để làm đường.
+ageofheroes-approve = Chấp thuận
+ageofheroes-deny = Từ chối
+ageofheroes-supply-exhausted = Không còn { $building } để xây nữa.
+
+# Không làm gì
+ageofheroes-do-nothing = { $player } bỏ lượt.
+ageofheroes-do-nothing-you = Bạn bỏ lượt...
+
+# Chiến tranh
+ageofheroes-war-declare = { $attacker } tuyên chiến với { $defender }. Mục tiêu: { $goal }.
+ageofheroes-war-prepare = Chọn quân đội để { $action }.
+ageofheroes-war-no-army = Bạn không có quân đội hay tướng lĩnh nào.
+ageofheroes-war-no-targets = Không có mục tiêu hợp lệ để tuyên chiến.
+ageofheroes-war-no-valid-goal = Không có mục tiêu chiến tranh hợp lệ với đối thủ này.
+ageofheroes-war-select-target = Chọn người chơi để tấn công.
+ageofheroes-war-select-goal = Chọn mục tiêu chiến tranh.
+ageofheroes-war-prepare-attack = Chọn lực lượng tấn công.
+ageofheroes-war-prepare-defense = { $attacker } đang tấn công bạn; Chọn lực lượng phòng thủ.
+ageofheroes-war-select-armies = Chọn số quân: { $count }
+ageofheroes-war-select-generals = Chọn số tướng: { $count }
+ageofheroes-war-select-heroes = Chọn anh hùng: { $count }
+ageofheroes-war-attack = Tấn công...
+ageofheroes-war-defend = Phòng thủ...
+ageofheroes-war-prepared = Lực lượng của bạn: { $armies } { $armies ->
+    [one] quân đoàn
+   *[other] quân đoàn
+}{ $generals ->
+    [0] {""}
+    [one] {", 1 tướng"}
+   *[other] {", { $generals } tướng"}
+}{ $heroes ->
+    [0] {""}
+    [one] {", 1 anh hùng"}
+   *[other] {", { $heroes } anh hùng"}
+}.
+ageofheroes-war-roll-you = Bạn gieo được { $roll }.
+ageofheroes-war-roll-other = { $player } gieo được { $roll }.
+ageofheroes-war-bonuses-you = { $general ->
+    [0] {
+        { $fortress ->
+            [0] {""}
+            [1] {"+1 từ pháo đài = tổng { $total }"}
+           *[other] {"+{ $fortress } từ pháo đài = tổng { $total }"}
+        }
+    }
+   *[other] {
+        { $fortress ->
+            [0] {"+{ $general } từ tướng = tổng { $total }"}
+            [1] {"+{ $general } từ tướng, +1 từ pháo đài = tổng { $total }"}
+           *[other] {"+{ $general } từ tướng, +{ $fortress } từ pháo đài = tổng { $total }"}
+        }
+    }
+}
+ageofheroes-war-bonuses-other = { $general ->
+    [0] {
+        { $fortress ->
+            [0] {""}
+            [1] {"{ $player }: +1 từ pháo đài = tổng { $total }"}
+           *[other] {"{ $player }: +{ $fortress } từ pháo đài = tổng { $total }"}
+        }
+    }
+   *[other] {
+        { $fortress ->
+            [0] {"{ $player }: +{ $general } từ tướng = tổng { $total }"}
+            [1] {"{ $player }: +{ $general } từ tướng, +1 từ pháo đài = tổng { $total }"}
+           *[other] {"{ $player }: +{ $general } từ tướng, +{ $fortress } từ pháo đài = tổng { $total }"}
+        }
+    }
+}
+
+# Trận chiến
+ageofheroes-battle-start = Trận chiến bắt đầu. { $att_armies } { $att_armies ->
+    [one] quân đoàn
+   *[other] quân đoàn
+} của { $attacker } đấu với { $def_armies } { $def_armies ->
+    [one] quân đoàn
+   *[other] quân đoàn
+} của { $defender }.
+ageofheroes-dice-roll-detailed = { $name } gieo được { $dice }{ $general ->
+    [0] {""}
+   *[other] { " + { $general } từ tướng" }
+}{ $fortress ->
+    [0] {""}
+    [one] { " + 1 từ pháo đài" }
+   *[other] { " + { $fortress } từ pháo đài" }
+} = { $total }.
+ageofheroes-dice-roll-detailed-you = Bạn gieo được { $dice }{ $general ->
+    [0] {""}
+   *[other] { " + { $general } từ tướng" }
+}{ $fortress ->
+    [0] {""}
+    [one] { " + 1 từ pháo đài" }
+   *[other] { " + { $fortress } từ pháo đài" }
+} = { $total }.
+ageofheroes-round-attacker-wins = { $attacker } thắng hiệp này ({ $att_total } đấu { $def_total }). { $defender } mất một quân đoàn.
+ageofheroes-round-defender-wins = { $defender } thủ thành công ({ $def_total } đấu { $att_total }). { $attacker } mất một quân đoàn.
+ageofheroes-round-draw = Hai bên hòa ở mức { $total }. Không ai mất quân.
+ageofheroes-battle-victory-attacker = { $attacker } đánh bại { $defender }.
+ageofheroes-battle-victory-defender = { $defender } phòng thủ thành công trước { $attacker }.
+ageofheroes-battle-mutual-defeat = Cả { $attacker } và { $defender } đều mất hết quân.
+ageofheroes-general-bonus = +{ $count } từ { $count ->
+    [one] tướng
+   *[other] tướng
+}
+ageofheroes-fortress-bonus = +{ $count } phòng thủ từ pháo đài
+ageofheroes-battle-winner = { $winner } thắng trận.
+ageofheroes-battle-draw = Trận chiến kết thúc hòa...
+ageofheroes-battle-continue = Tiếp tục trận chiến.
+ageofheroes-battle-end = Trận chiến kết thúc.
+
+# Kết quả chiến tranh
+ageofheroes-conquest-success = { $attacker } chinh phục { $count } { $count ->
+    [one] thành phố
+   *[other] thành phố
+} của { $defender }.
+ageofheroes-plunder-success = { $attacker } cướp bóc { $count } { $count ->
+    [one] lá bài
+   *[other] lá bài
+} của { $defender }.
+ageofheroes-destruction-success = { $attacker } phá hủy { $count } { $count ->
+    [one] tài nguyên kỳ quan
+   *[other] tài nguyên kỳ quan
+} của { $defender }.
+ageofheroes-army-losses = { $player } tổn thất { $count } { $count ->
+    [one] quân đoàn
+   *[other] quân đoàn
+}.
+ageofheroes-army-losses-you = Bạn tổn thất { $count } { $count ->
+    [one] quân đoàn
+   *[other] quân đoàn
+}.
+
+# Quân đội trở về
+ageofheroes-army-return-road = Quân của bạn trở về ngay lập tức qua đường bộ.
+ageofheroes-army-return-delayed = { $count } { $count ->
+    [one] đơn vị sẽ về
+   *[other] đơn vị sẽ về
+} vào cuối lượt sau của bạn.
+ageofheroes-army-returned = Quân của { $player } đã trở về sau chiến tranh.
+ageofheroes-army-returned-you = Quân của bạn đã trở về sau chiến tranh.
+ageofheroes-army-recover = Quân đội của { $player } đang hồi phục sau động đất.
+ageofheroes-army-recover-you = Quân đội của bạn đang hồi phục sau động đất.
+
+# Thế vận hội
+ageofheroes-olympics-cancel = { $player } tổ chức Thế vận hội Olympic. Chiến tranh bị hủy bỏ.
+ageofheroes-olympics-prompt = { $attacker } đã tuyên chiến. Bạn có lá Thế vận hội - dùng để hủy chiến tranh không?
+ageofheroes-yes = Có
+ageofheroes-no = Không
+
+# Tiến độ kỳ quan
+ageofheroes-monument-progress = Kỳ quan của { $player } đã hoàn thành { $count }/5.
+ageofheroes-monument-progress-you = Kỳ quan của bạn đã hoàn thành { $count }/5.
+
+# Quản lý bài trên tay
+ageofheroes-discard-excess = Bạn có nhiều hơn { $max } lá bài. Hãy bỏ { $count } { $count ->
+    [one] lá
+   *[other] lá
+}.
+ageofheroes-discard-excess-other = { $player } phải bỏ bớt bài thừa.
+ageofheroes-discard-more = Bỏ thêm { $count } { $count ->
+    [one] lá
+   *[other] lá
+}.
+
+# Chiến thắng
+ageofheroes-victory-cities = { $player } đã xây được 5 thành phố! Đế chế Năm Thành Phố.
+ageofheroes-victory-cities-you = Bạn đã xây được 5 thành phố! Đế chế Năm Thành Phố.
+ageofheroes-victory-monument = { $player } đã hoàn thành kỳ quan! Những người kiến tạo Văn minh Vĩ đại.
+ageofheroes-victory-monument-you = Bạn đã hoàn thành kỳ quan! Những người kiến tạo Văn minh Vĩ đại.
+ageofheroes-victory-last-standing = { $player } là bộ tộc cuối cùng còn trụ lại! Kẻ Kiên Cường Nhất.
+ageofheroes-victory-last-standing-you = Bạn là bộ tộc cuối cùng còn trụ lại! Kẻ Kiên Cường Nhất.
+ageofheroes-game-over = Kết thúc trò chơi.
+
+# Loại bỏ
+ageofheroes-eliminated = { $player } đã bị loại.
+ageofheroes-eliminated-you = Bạn đã bị loại.
+
+# Bài trên tay
+ageofheroes-hand-empty = Bạn không có bài.
+ageofheroes-hand-contents = Bài trên tay ({ $count } { $count ->
+    [one] lá
+   *[other] lá
+}): { $cards }
+
+# Trạng thái
+ageofheroes-status = { $player } ({ $tribe }): { $cities } { $cities ->
+    [one] thành phố
+   *[other] thành phố
+}, { $armies } { $armies ->
+    [one] quân đoàn
+   *[other] quân đoàn
+}, kỳ quan { $monument }/5
+ageofheroes-status-detailed-header = { $player } ({ $tribe })
+ageofheroes-status-cities = Thành phố: { $count }
+ageofheroes-status-armies = Quân đội: { $count }
+ageofheroes-status-generals = Tướng lĩnh: { $count }
+ageofheroes-status-fortresses = Pháo đài: { $count }
+ageofheroes-status-monument = Kỳ quan: { $count }/5
+ageofheroes-status-roads = Đường xá: { $left }{ $right }
+ageofheroes-status-road-left = trái
+ageofheroes-status-road-right = phải
+ageofheroes-status-none = không có
+ageofheroes-status-earthquake-armies = Quân đang hồi phục: { $count }
+ageofheroes-status-returning-armies = Quân đang trở về: { $count }
+ageofheroes-status-returning-generals = Tướng đang trở về: { $count }
+
+# Thông tin bộ bài
+ageofheroes-deck-empty = Không còn lá { $card } trong bộ.
+ageofheroes-deck-count = Số bài còn lại: { $count }
+ageofheroes-deck-reshuffled = Chồng bài bỏ đã được xào lại vào bộ bài.
+
+# Đầu hàng
+ageofheroes-give-up-confirm = Bạn có chắc muốn bỏ cuộc không?
+ageofheroes-gave-up = { $player } đã bỏ cuộc!
+ageofheroes-gave-up-you = Bạn đã bỏ cuộc!
+
+# Lá bài Anh hùng
+ageofheroes-hero-use = Dùng như Quân đội hay Tướng lĩnh?
+ageofheroes-hero-army = Quân đội
+ageofheroes-hero-general = Tướng lĩnh
+
+# Lá bài Vận may
+ageofheroes-fortune-reroll = { $player } dùng Vận may để gieo lại.
+ageofheroes-fortune-prompt = Bạn đã thua lượt gieo này. Dùng Vận may để gieo lại không?
+
+# Lý do hành động bị vô hiệu hóa
+ageofheroes-not-your-turn = Chưa đến lượt bạn.
+ageofheroes-game-not-started = Trò chơi chưa bắt đầu.
+ageofheroes-wrong-phase = Hành động này không khả dụng trong giai đoạn hiện tại.
+ageofheroes-no-resources = Bạn không đủ tài nguyên yêu cầu.
+
+# Chi phí xây dựng (để hiển thị)
+ageofheroes-cost-army = 2 Ngũ cốc, Sắt
+ageofheroes-cost-fortress = Sắt, Gỗ, Đá
+ageofheroes-cost-general = Sắt, Vàng
+ageofheroes-cost-road = 2 Đá
+ageofheroes-cost-city = 2 Gỗ, Đá

--- a/server/locales/vi/chaosbear.ftl
+++ b/server/locales/vi/chaosbear.ftl
@@ -1,0 +1,52 @@
+# Thông báo trò chơi Chaos Bear
+
+# Tên trò chơi
+game-name-chaosbear = Gấu Hỗn Mang
+
+# Hành động
+chaosbear-roll-dice = Gieo xúc xắc
+chaosbear-draw-card = Rút thẻ
+chaosbear-check-status = Kiểm tra trạng thái
+
+# Giới thiệu game (3 thông báo riêng biệt như bản v10)
+chaosbear-intro-1 = Gấu Hỗn Mang đã bắt đầu! Tất cả người chơi xuất phát trước Gấu 30 ô.
+chaosbear-intro-2 = Gieo xúc xắc để tiến lên, và rút thẻ tại các ô là bội số của 5 để nhận hiệu ứng đặc biệt.
+chaosbear-intro-3 = Đừng để Gấu bắt được bạn!
+
+# Thông báo lượt
+chaosbear-turn = Lượt của { $player }; đang ở ô { $position }.
+
+# Gieo xúc xắc
+chaosbear-roll = { $player } gieo được { $roll }.
+chaosbear-position = { $player } hiện đang ở ô { $position }.
+
+# Rút thẻ
+chaosbear-draws-card = { $player } rút một thẻ.
+chaosbear-card-impulsion = Tăng tốc! { $player } tiến thêm 3 ô đến ô { $position }!
+chaosbear-card-super-impulsion = Siêu tăng tốc! { $player } tiến thêm 5 ô đến ô { $position }!
+chaosbear-card-tiredness = Mệt mỏi! Gấu bị trừ 1 năng lượng. Nó còn { $energy } năng lượng.
+chaosbear-card-hunger = Cơn đói! Gấu được cộng 1 năng lượng. Nó đang có { $energy } năng lượng.
+chaosbear-card-backward = Đẩy lùi! { $player } bị đẩy lùi về ô { $position }.
+chaosbear-card-random-gift = Quà ngẫu nhiên!
+chaosbear-gift-back = { $player } bị lùi về ô { $position }.
+chaosbear-gift-forward = { $player } được tiến đến ô { $position }!
+
+# Lượt của Gấu
+chaosbear-bear-roll = Gấu gieo được { $roll } + { $energy } năng lượng = { $total }.
+chaosbear-bear-energy-up = Gấu gieo được 3 và tăng thêm 1 năng lượng!
+chaosbear-bear-position = Gấu hiện đang ở ô { $position }!
+chaosbear-player-caught = Gấu đã tóm được { $player }! { $player } đã bị đánh bại!
+chaosbear-bear-feast = Gấu giảm 3 năng lượng sau khi "đánh chén" con mồi!
+
+# Kiểm tra trạng thái
+chaosbear-status-player-alive = { $player }: ô { $position }.
+chaosbear-status-player-caught = { $player }: bị bắt tại ô { $position }.
+chaosbear-status-bear = Gấu đang ở ô { $position } với { $energy } năng lượng.
+
+# Kết thúc game
+chaosbear-winner = { $player } sống sót và chiến thắng! Họ đã đến được ô { $position }!
+chaosbear-tie = Hòa nhau tại ô { $position }!
+
+# Lý do hành động bị vô hiệu hóa
+chaosbear-you-are-caught = Bạn đã bị gấu bắt.
+chaosbear-not-on-multiple = Bạn chỉ có thể rút thẻ ở các ô là bội số của 5 (5, 10, 15...).

--- a/server/locales/vi/farkle.ftl
+++ b/server/locales/vi/farkle.ftl
@@ -1,0 +1,51 @@
+# Thông báo trò chơi Farkle
+
+# Thông tin game
+game-name-farkle = Farkle
+
+# Hành động - Gieo và Chốt
+farkle-roll = Gieo { $count } { $count ->
+    [one] viên
+   *[other] viên
+}
+farkle-bank = Chốt { $points } điểm
+
+# Hành động chọn tổ hợp điểm (khớp với bản v10)
+farkle-take-single-one = Lấy con 1 lẻ được { $points } điểm
+farkle-take-single-five = Lấy con 5 lẻ được { $points } điểm
+farkle-take-three-kind = Lấy bộ ba con { $number } được { $points } điểm
+farkle-take-four-kind = Lấy tứ quý { $number } được { $points } điểm
+farkle-take-five-kind = Lấy ngũ quý { $number } được { $points } điểm
+farkle-take-six-kind = Lấy lục quý { $number } được { $points } điểm
+farkle-take-small-straight = Lấy Sảnh nhỏ được { $points } điểm
+farkle-take-large-straight = Lấy Sảnh lớn được { $points } điểm
+farkle-take-three-pairs = Lấy 3 đôi được { $points } điểm
+farkle-take-double-triplets = Lấy 2 bộ ba được { $points } điểm
+farkle-take-full-house = Lấy Cù lũ được { $points } điểm
+
+# Sự kiện trong game
+farkle-rolls = { $player } gieo { $count } { $count ->
+    [one] viên
+   *[other] viên
+}...
+farkle-roll-result = { $dice }
+farkle-farkle = CHÁY ĐIỂM! { $player } mất { $points } điểm
+farkle-takes-combo = { $player } lấy { $combo } được { $points } điểm
+farkle-you-take-combo = Bạn lấy { $combo } được { $points } điểm
+farkle-hot-dice = Ăn trọn! (Hot dice)
+farkle-banks = { $player } chốt { $points } điểm, tổng cộng có { $total }
+farkle-winner = { $player } thắng với { $score } điểm!
+farkle-winners-tie = Hòa nhau rồi! Những người thắng: { $players }
+
+# Kiểm tra điểm lượt này
+farkle-turn-score = Lượt này { $player } đang có { $points } điểm.
+farkle-no-turn = Hiện không có ai đang chơi lượt của mình.
+
+# Tùy chọn riêng cho Farkle
+farkle-set-target-score = Điểm mục tiêu: { $score }
+farkle-enter-target-score = Nhập điểm mục tiêu (500-5000):
+farkle-option-changed-target = Điểm mục tiêu đã đặt là { $score }.
+
+# Lý do hành động bị vô hiệu hóa
+farkle-must-take-combo = Bạn phải chọn tổ hợp ăn điểm trước.
+farkle-cannot-bank = Bạn không thể chốt điểm lúc này.

--- a/server/locales/vi/fivecarddraw.ftl
+++ b/server/locales/vi/fivecarddraw.ftl
@@ -1,0 +1,37 @@
+# Five Card Draw (Poker Rút 5 Lá)
+
+game-name-fivecarddraw = Poker Rút 5 Lá
+
+draw-set-starting-chips = Chip khởi điểm: { $count }
+draw-enter-starting-chips = Nhập số chip khởi điểm
+draw-option-changed-starting-chips = Số chip khởi điểm đã đặt là { $count }.
+
+draw-set-ante = Cược đáy (Ante): { $count }
+draw-enter-ante = Nhập số tiền cược đáy
+draw-option-changed-ante = Cược đáy đã đặt là { $count }.
+
+draw-set-turn-timer = Thời gian lượt: { $mode }
+draw-select-turn-timer = Chọn thời gian lượt
+draw-option-changed-turn-timer = Thời gian lượt đã đặt là { $mode }.
+
+draw-set-raise-mode = Chế độ tố: { $mode }
+draw-select-raise-mode = Chọn chế độ tố
+draw-option-changed-raise-mode = Chế độ tố đã đặt là { $mode }.
+
+draw-set-max-raises = Tố tối đa: { $count } lần
+draw-enter-max-raises = Nhập số lần tố tối đa (0 là không giới hạn)
+draw-option-changed-max-raises = Số lần tố tối đa đã đặt là { $count }.
+
+draw-antes-posted = Đã đặt cược đáy: { $amount }.
+draw-betting-round-1 = Vòng cược 1.
+draw-betting-round-2 = Vòng cược 2.
+draw-begin-draw = Giai đoạn đổi bài.
+
+draw-toggle-discard = Chọn bỏ lá bài thứ { $index }
+draw-draw-cards = Đổi bài
+draw-you-draw = Bạn đổi { $count } lá.
+draw-player-draws = { $player } đổi { $count } lá.
+draw-you-stand-pat = Bạn giữ nguyên bài.
+draw-player-stands-pat = { $player } giữ nguyên bài.
+draw-you-discard-limit = Bạn có thể bỏ tối đa { $count } lá.
+draw-player-discard-limit = { $player } có thể bỏ tối đa { $count } lá.

--- a/server/locales/vi/games.ftl
+++ b/server/locales/vi/games.ftl
@@ -1,0 +1,118 @@
+# Thông báo chung cho các trò chơi trong PlayPalace
+# Những thông báo này dùng chung cho nhiều trò chơi
+
+# Tên trò chơi
+game-name-ninetynine = Ninety Nine
+
+# Luồng vòng chơi và lượt
+game-round-start = Vòng { $round }.
+game-round-end = Vòng { $round } hoàn tất.
+game-turn-start = Lượt của { $player }.
+game-no-turn = Hiện không phải lượt của ai.
+
+# Hiển thị điểm số
+game-scores-header = Điểm hiện tại:
+game-score-line = { $player }: { $score } điểm
+game-final-scores-header = Điểm tổng kết:
+
+# Thắng/Thua
+game-winner = { $player } thắng!
+game-winner-score = { $player } thắng với { $score } điểm!
+game-tiebreaker = Hòa rồi! Vào vòng phân định thắng thua!
+game-tiebreaker-players = Hòa giữa các người chơi { $players }! Vào vòng phân định thắng thua!
+game-eliminated = { $player } đã bị loại với { $score } điểm.
+
+# Tùy chọn chung
+game-set-target-score = Điểm mục tiêu: { $score }
+game-enter-target-score = Nhập điểm mục tiêu:
+game-option-changed-target = Điểm mục tiêu đã đặt là { $score }.
+
+game-set-team-mode = Chế độ đội: { $mode }
+game-select-team-mode = Chọn chế độ đội
+game-option-changed-team = Chế độ đội đã đặt là { $mode }.
+game-team-mode-individual = Cá nhân
+game-team-mode-x-teams-of-y = { $num_teams } đội, mỗi đội { $team_size } người
+
+# Giá trị tùy chọn Bật/Tắt
+option-on = bật
+option-off = tắt
+
+# Hộp trạng thái
+status-box-closed = Đã đóng thông tin trạng thái.
+
+# Kết thúc game
+game-leave = Rời trò chơi
+
+# Đồng hồ vòng chơi
+round-timer-paused = { $player } đã tạm dừng (nhấn p để bắt đầu vòng sau).
+round-timer-resumed = Đồng hồ vòng chơi tiếp tục chạy.
+round-timer-countdown = Vòng tiếp theo trong { $seconds } giây...
+
+# Game xúc xắc - giữ/bỏ xúc xắc
+dice-keeping = Giữ { $value }.
+dice-rerolling = Gieo lại { $value }.
+dice-locked = Viên này đã bị khóa, không thể đổi.
+
+# Chia bài (Game bài)
+game-deal-counter = Chia ván { $current }/{ $total }.
+game-you-deal = Bạn chia bài.
+game-player-deals = { $player } chia bài.
+
+# Tên lá bài
+# Cấu trúc: [Tên] [Chất] (ví dụ: Át cơ)
+card-name = { $rank } { $suit }
+no-cards = Không có bài
+
+# Tên chất bài
+suit-diamonds = rô
+suit-clubs = tép
+suit-hearts = cơ
+suit-spades = bích
+
+# Tên quân bài (Số/Hàng)
+rank-ace = Át
+rank-ace-plural = Át
+rank-two = 2
+rank-two-plural = 2
+rank-three = 3
+rank-three-plural = 3
+rank-four = 4
+rank-four-plural = 4
+rank-five = 5
+rank-five-plural = 5
+rank-six = 6
+rank-six-plural = 6
+rank-seven = 7
+rank-seven-plural = 7
+rank-eight = 8
+rank-eight-plural = 8
+rank-nine = 9
+rank-nine-plural = 9
+rank-ten = 10
+rank-ten-plural = 10
+rank-jack = Bồi
+rank-jack-plural = Bồi
+rank-queen = Đầm
+rank-queen-plural = Đầm
+rank-king = Già
+rank-king-plural = Già
+
+# Mô tả tay bài Poker (Thuần Việt)
+poker-high-card-with = Mậu thầu { $high }, kèm { $rest }
+poker-high-card = Mậu thầu { $high }
+poker-pair-with = Đôi { $pair }, kèm { $rest }
+poker-pair = Đôi { $pair }
+poker-two-pair-with = Thú { $high } và { $low }, kèm { $kicker }
+poker-two-pair = Thú { $high } và { $low }
+poker-trips-with = Sám { $trips }, kèm { $rest }
+poker-trips = Sám { $trips }
+poker-straight-high = Sảnh { $high }
+poker-flush-high-with = Thùng { $high }, kèm { $rest }
+poker-full-house = Cù lũ { $trips }, đôi { $pair }
+poker-quads-with = Tứ quý { $quads }, kèm { $kicker }
+poker-quads = Tứ quý { $quads }
+poker-straight-flush-high = Thùng phá sảnh { $high }
+poker-unknown-hand = Bài không xác định
+
+# Lỗi xác thực (chung)
+game-error-invalid-team-mode = Chế độ đội đã chọn không hợp lệ với số lượng người chơi hiện tại.

--- a/server/locales/vi/holdem.ftl
+++ b/server/locales/vi/holdem.ftl
@@ -1,0 +1,38 @@
+# Texas Hold'em
+
+game-name-holdem = Texas Hold'em
+
+holdem-set-starting-chips = Chip khởi điểm: { $count }
+holdem-enter-starting-chips = Nhập số chip khởi điểm
+holdem-option-changed-starting-chips = Số chip khởi điểm đã đặt là { $count }.
+
+holdem-set-big-blind = Mù lớn (Big Blind): { $count }
+holdem-enter-big-blind = Nhập tiền mù lớn
+holdem-option-changed-big-blind = Mù lớn đã đặt là { $count }.
+
+holdem-set-ante = Cược đáy (Ante): { $count }
+holdem-enter-ante = Nhập tiền cược đáy
+holdem-option-changed-ante = Cược đáy đã đặt là { $count }.
+
+holdem-set-ante-start = Cược đáy bắt đầu từ cấp: { $count }
+holdem-enter-ante-start = Nhập cấp độ mù để bắt đầu có cược đáy
+holdem-option-changed-ante-start = Cấp độ bắt đầu cược đáy đã đặt là { $count }.
+
+holdem-set-turn-timer = Thời gian lượt: { $mode }
+holdem-select-turn-timer = Chọn thời gian lượt
+holdem-option-changed-turn-timer = Thời gian lượt đã đặt là { $mode }.
+
+holdem-set-blind-timer = Thời gian tăng mù: { $mode }
+holdem-select-blind-timer = Chọn thời gian tăng mù
+holdem-option-changed-blind-timer = Thời gian tăng mù đã đặt là { $mode }.
+
+holdem-set-raise-mode = Chế độ tố: { $mode }
+holdem-select-raise-mode = Chọn chế độ tố
+holdem-option-changed-raise-mode = Chế độ tố đã đặt là { $mode }.
+
+holdem-set-max-raises = Tố tối đa: { $count } lần
+holdem-enter-max-raises = Nhập số lần tố tối đa (0 là không giới hạn)
+holdem-option-changed-max-raises = Số lần tố tối đa đã đặt là { $count }.
+
+holdem-antes-posted = Đã đặt cược đáy: { $amount }.
+holdem-blinds-posted = Đã đặt tiền mù: { $sb } / { $bb }.

--- a/server/locales/vi/leftrightcenter.ftl
+++ b/server/locales/vi/leftrightcenter.ftl
@@ -1,0 +1,49 @@
+# Thông báo cho trò chơi Left Right Center
+
+# Tên trò chơi
+game-name-leftrightcenter = Left Right Center
+
+# Hành động
+lrc-roll = Gieo { $count } { $count ->
+    [one] viên
+   *[other] viên
+}
+
+# Các mặt xúc xắc
+lrc-face-left = Trái
+lrc-face-right = Phải
+lrc-face-center = Giữa
+lrc-face-dot = Chấm
+
+# Sự kiện trong game
+lrc-roll-results = { $player } gieo được { $results }.
+lrc-pass-left = { $player } chuyển { $count } { $count ->
+    [one] chip
+   *[other] chip
+} cho { $target }.
+lrc-pass-right = { $player } chuyển { $count } { $count ->
+    [one] chip
+   *[other] chip
+} cho { $target }.
+lrc-pass-center = { $player } bỏ { $count } { $count ->
+    [one] chip
+   *[other] chip
+} vào giữa.
+lrc-no-chips = { $player } không còn chip để gieo.
+lrc-center-pot = Giữa bàn đang có { $count } { $count ->
+    [one] chip
+   *[other] chip
+}.
+lrc-player-chips = { $player } hiện có { $count } { $count ->
+    [one] chip
+   *[other] chip
+}.
+lrc-winner = { $player } thắng với { $count } { $count ->
+    [one] chip
+   *[other] chip
+}!
+
+# Tùy chọn
+lrc-set-starting-chips = Chip khởi điểm: { $count }
+lrc-enter-starting-chips = Nhập số chip khởi điểm:
+lrc-option-changed-starting-chips = Số chip khởi điểm đã đặt là { $count }.

--- a/server/locales/vi/lightturret.ftl
+++ b/server/locales/vi/lightturret.ftl
@@ -1,0 +1,45 @@
+# Thông báo trò chơi Light Turret
+
+# Tên trò chơi
+game-name-lightturret = Tháp Ánh Sáng
+
+# Giới thiệu
+lightturret-intro = Tháp Ánh Sáng đã khởi động! Mỗi người chơi sở hữu một ngọn tháp với { $power } sức mạnh. Hãy bắn vào tháp để thu thập ánh sáng và xu, nhưng cẩn thận: nếu lượng ánh sáng vượt quá sức mạnh, bạn sẽ bị loại! Dùng xu mua nâng cấp để tăng sức mạnh. Người có nhiều ánh sáng nhất vào cuối trận sẽ chiến thắng!
+
+# Hành động
+lightturret-shoot = Bắn vào tháp
+lightturret-upgrade = Mua nâng cấp (10 xu)
+lightturret-check-stats = Xem chỉ số
+
+# Kết quả hành động
+lightturret-shoot-result = { $player } bắn vào tháp và thu được { $gain } ánh sáng! Hiện tháp đang chứa { $light } ánh sáng.
+lightturret-coins-gained = { $player } nhận được { $coins } xu! { $player } hiện có { $total } xu.
+lightturret-buys-upgrade = { $player } mua nâng cấp sức mạnh!
+lightturret-power-gained = { $player } tăng { $gain } sức mạnh! { $player } hiện có { $power } sức mạnh.
+lightturret-upgrade-accident = Gói nâng cấp vô tình bị hòa vào tháp! Kết quả là tháp nhận được { $light } ánh sáng.
+lightturret-not-enough-coins = Bạn không đủ xu! Cần { $need } xu nhưng chỉ có { $have }.
+
+# Loại bỏ
+lightturret-eliminated = Lượng ánh sáng quá lớn khiến linh hồn { $player } không chịu nổi! { $player } đã bị loại!
+
+# Chỉ số
+lightturret-stats-alive = { $player }: { $power } sức mạnh, { $light } ánh sáng, { $coins } xu.
+lightturret-stats-eliminated = { $player }: bị loại với { $light } ánh sáng.
+
+# Kết thúc game
+lightturret-game-over = Trò chơi kết thúc!
+lightturret-final-alive = { $player } hoàn thành với { $light } ánh sáng.
+lightturret-final-eliminated = { $player } đã bị loại với { $light } ánh sáng.
+lightturret-winner = { $player } thắng với { $light } ánh sáng!
+lightturret-tie = Hòa nhau với { $light } ánh sáng!
+
+# Tùy chọn
+lightturret-set-starting-power = Sức mạnh khởi đầu: { $power }
+lightturret-enter-starting-power = Nhập sức mạnh khởi đầu:
+lightturret-option-changed-power = Sức mạnh khởi đầu đã đặt là { $power }.
+lightturret-set-max-rounds = Số vòng tối đa: { $rounds }
+lightturret-enter-max-rounds = Nhập số vòng tối đa:
+lightturret-option-changed-rounds = Số vòng tối đa đã đặt là { $rounds }.
+
+# Lý do hành động bị vô hiệu hóa
+lightturret-you-are-eliminated = Bạn đã bị loại.

--- a/server/locales/vi/main.ftl
+++ b/server/locales/vi/main.ftl
@@ -1,0 +1,216 @@
+# Thông báo giao diện chính cho PlayPalace
+
+# Danh mục trò chơi
+category-card-games = Game Bài
+category-dice-games = Game Xúc Xắc
+category-rb-play-center = Trung tâm Giải trí RB
+category-poker = Poker
+category-uncategorized = Chưa phân loại
+
+# Tiêu đề menu
+main-menu-title = Menu Chính
+play-menu-title = Chơi
+categories-menu-title = Danh mục Trò chơi
+tables-menu-title = Danh sách Bàn
+
+# Các mục trong menu
+play = Chơi
+options = Tùy chọn
+logout = Đăng xuất
+back = Quay lại
+go-back = Quay lại
+context-menu = Menu ngữ cảnh.
+no-actions-available = Không có hành động nào.
+create-table = Tạo bàn mới
+join-as-player = Vào chơi
+join-as-spectator = Vào xem
+leave-table = Rời bàn
+start-game = Bắt đầu game
+add-bot = Thêm Bot
+remove-bot = Xóa Bot
+actions-menu = Menu hành động
+save-table = Lưu bàn
+whose-turn = Đến lượt ai?
+check-scores = Xem điểm
+check-scores-detailed = Chi tiết điểm số
+
+# Thông báo lượt
+game-player-skipped = { $player } bị bỏ qua.
+
+# Thông báo về bàn chơi
+table-created = { $host } đã tạo một bàn { $game } mới.
+table-joined = { $player } đã tham gia bàn.
+table-left = { $player } đã rời bàn.
+new-host = { $player } giờ là chủ bàn.
+waiting-for-players = Đang chờ người chơi. Tối thiểu { $current }/{ $min }, tối đa { $max }.
+game-starting = Trò chơi bắt đầu!
+table-listing = Bàn của { $host } ({ $count } người chơi)
+table-not-exists = Bàn không còn tồn tại.
+table-full = Bàn đã đầy.
+player-replaced-by-bot = { $player } đã thoát và được thay thế bởi Bot.
+player-took-over = { $player } đã thế chỗ cho Bot.
+spectator-joined = Đã vào xem bàn của { $host }.
+
+# Chế độ khán giả
+spectate = Xem
+now-playing = { $player } đang chơi.
+now-spectating = { $player } đang xem.
+
+# Chung
+welcome = Chào mừng đến với PlayPalace!
+goodbye = Tạm biệt!
+
+# Thông báo trạng thái người dùng
+user-online = { $player } vừa online.
+user-offline = { $player } đã offline.
+
+# Tùy chọn
+language = Ngôn ngữ
+language-english = Tiếng Anh
+language-option = Ngôn ngữ: { $language }
+language-changed = Ngôn ngữ đã đổi sang { $language }.
+
+# Trạng thái tùy chọn Bật/Tắt
+option-on = Bật
+option-off = Tắt
+
+# Tùy chọn âm thanh
+turn-sound-option = Âm thanh báo lượt: { $status }
+
+# Tùy chọn xúc xắc
+clear-kept-option = Bỏ chọn xúc xắc đã giữ khi gieo lại: { $status }
+dice-keeping-style-option = Kiểu giữ xúc xắc: { $style }
+dice-keeping-style-changed = Kiểu giữ xúc xắc đã đặt là { $style }.
+
+# Tên Bot
+cancel = Hủy
+no-bot-names-available = Không có tên Bot nào.
+select-bot-name = Chọn tên cho Bot
+enter-bot-name = Nhập tên Bot
+no-options-available = Không có tùy chọn nào.
+no-scores-available = Chưa có điểm số.
+
+# Ước tính thời gian
+estimate-duration = Ước tính thời gian
+estimate-computing = Đang tính toán thời gian chơi dự kiến...
+estimate-result = Trung bình Bot: { $bot_time } (± { $std_dev }). { $outlier_info }Dự tính người chơi: { $human_time }.
+estimate-error = Không thể ước tính thời gian.
+estimate-already-running = Đang trong quá trình ước tính thời gian.
+
+# Lưu/Khôi phục
+saved-tables = Bàn đã lưu
+no-saved-tables = Bạn chưa lưu bàn nào.
+restore-table = Khôi phục
+delete-saved-table = Xóa
+saved-table-deleted = Đã xóa bàn đã lưu.
+missing-players = Không thể khôi phục: thiếu những người chơi sau: { $players }
+table-restored = Đã khôi phục bàn! Tất cả người chơi đã được chuyển vào.
+table-saved-destroying = Đã lưu bàn! Đang quay về menu chính.
+game-type-not-found = Loại trò chơi không còn tồn tại.
+
+# Lý do không thực hiện được hành động
+action-not-your-turn = Chưa đến lượt bạn.
+action-not-playing = Trò chơi chưa bắt đầu.
+action-spectator = Khán giả không được làm thao tác này.
+action-not-host = Chỉ chủ bàn mới làm được thao tác này.
+action-game-in-progress = Không thể làm lúc đang chơi.
+action-need-more-players = Cần thêm người chơi để bắt đầu.
+action-table-full = Bàn đã đầy.
+action-no-bots = Không có Bot nào để xóa.
+action-bots-cannot = Bot không thể làm thao tác này.
+action-no-scores = Chưa có điểm số nào.
+
+# Hành động xúc xắc
+dice-not-rolled = Bạn chưa gieo xúc xắc.
+dice-locked = Viên này đã bị khóa.
+dice-no-dice = Không có xúc xắc.
+
+# Hành động trong game
+game-turn-start = Lượt của { $player }.
+game-no-turn = Hiện không phải lượt của ai.
+game-leave = Rời bỏ
+game-over = Kết thúc
+game-final-scores = Điểm tổng kết
+game-points = { $count } { $count ->
+    [one] điểm
+   *[other] điểm
+}
+status-box-closed = Đã đóng.
+play = Chơi
+
+# Bảng xếp hạng
+leaderboards = Bảng xếp hạng
+leaderboards-menu-title = Bảng xếp hạng
+leaderboards-select-game = Chọn trò chơi để xem xếp hạng
+leaderboard-no-data = Chưa có dữ liệu xếp hạng cho trò này.
+
+# Các loại bảng xếp hạng
+leaderboard-type-wins = Top Thắng
+leaderboard-type-rating = Hệ số kỹ năng
+leaderboard-type-total-score = Tổng điểm
+leaderboard-type-high-score = Điểm cao nhất
+leaderboard-type-games-played = Số ván đã chơi
+leaderboard-type-avg-points-per-turn = Điểm trung bình mỗi lượt
+leaderboard-type-best-single-turn = Lượt chơi xuất sắc nhất
+leaderboard-type-score-per-round = Điểm mỗi vòng
+
+# Tiêu đề bảng xếp hạng
+leaderboard-wins-header = { $game } - Top Thắng
+leaderboard-total-score-header = { $game } - Tổng điểm
+leaderboard-high-score-header = { $game } - Điểm cao nhất
+leaderboard-games-played-header = { $game } - Số ván đã chơi
+leaderboard-rating-header = { $game } - Hệ số kỹ năng
+leaderboard-avg-points-header = { $game } - Điểm trung bình mỗi lượt
+leaderboard-best-turn-header = { $game } - Lượt chơi xuất sắc nhất
+leaderboard-score-per-round-header = { $game } - Điểm mỗi vòng
+
+# Nội dung bảng xếp hạng
+leaderboard-wins-entry = { $rank }: { $player }, { $wins } { $wins ->
+    [one] thắng
+   *[other] thắng
+} { $losses } { $losses ->
+    [one] thua
+   *[other] thua
+}, tỉ lệ thắng { $percentage }%
+leaderboard-score-entry = { $rank }. { $player }: { $value }
+leaderboard-avg-entry = { $rank }. { $player }: trung bình { $value }
+leaderboard-games-entry = { $rank }. { $player }: { $value } ván
+
+# Thống kê người chơi
+leaderboard-player-stats = Thống kê của bạn: { $wins } thắng, { $losses } thua (tỉ lệ thắng { $percentage }%)
+leaderboard-no-player-stats = Bạn chưa chơi trò này.
+
+# Bảng xếp hạng kỹ năng
+leaderboard-no-ratings = Chưa có dữ liệu kỹ năng cho trò này.
+leaderboard-rating-entry = { $rank }. { $player }: hệ số { $rating } ({ $mu } ± { $sigma })
+leaderboard-player-rating = Hệ số của bạn: { $rating } ({ $mu } ± { $sigma })
+leaderboard-no-player-rating = Bạn chưa có hệ số kỹ năng cho trò này.
+
+# Menu Thống kê của tôi
+my-stats = Thống kê của tôi
+my-stats-select-game = Chọn trò chơi để xem thống kê cá nhân
+my-stats-no-data = Bạn chưa chơi trò này.
+my-stats-no-games = Bạn chưa chơi ván nào.
+my-stats-header = { $game } - Thống kê của bạn
+my-stats-wins = Thắng: { $value }
+my-stats-losses = Thua: { $value }
+my-stats-winrate = Tỉ lệ thắng: { $value }%
+my-stats-games-played = Số ván đã chơi: { $value }
+my-stats-total-score = Tổng điểm: { $value }
+my-stats-high-score = Điểm cao nhất: { $value }
+my-stats-rating = Hệ số kỹ năng: { $value } ({ $mu } ± { $sigma })
+my-stats-no-rating = Chưa có hệ số kỹ năng
+my-stats-avg-per-turn = Điểm TB mỗi lượt: { $value }
+my-stats-best-turn = Lượt chơi tốt nhất: { $value }
+
+# Hệ thống dự đoán
+predict-outcomes = Dự đoán kết quả
+predict-header = Kết quả dự đoán (theo hệ số kỹ năng)
+predict-entry = { $rank }. { $player } (hệ số: { $rating })
+predict-entry-2p = { $rank }. { $player } (hệ số: { $rating }, cơ hội thắng { $probability }%)
+predict-unavailable = Không có sẵn dự đoán xếp hạng.
+predict-need-players = Cần ít nhất 2 người chơi thực để dự đoán.
+action-need-more-humans = Cần thêm người chơi thực.
+confirm-leave-game = Bạn có chắc muốn rời bàn không?
+confirm-yes = Có
+confirm-no = Không

--- a/server/locales/vi/midnight.ftl
+++ b/server/locales/vi/midnight.ftl
@@ -1,0 +1,53 @@
+# Thông báo trò chơi 1-4-24 (Midnight)
+# Lưu ý: Các thông báo chung như bắt đầu vòng, bắt đầu lượt, điểm mục tiêu nằm trong games.ftl
+
+# Thông tin game
+game-name-midnight = 1-4-24
+midnight-category = Game Xúc Xắc
+
+# Hành động
+midnight-roll = Gieo xúc xắc
+midnight-keep-die = Giữ con { $value }
+midnight-bank = Chốt điểm
+
+# Sự kiện trong game
+midnight-turn-start = Lượt của { $player }.
+midnight-you-rolled = Bạn gieo được: { $dice }.
+midnight-player-rolled = { $player } gieo được: { $dice }.
+
+# Giữ xúc xắc
+midnight-you-keep = Bạn giữ con { $die }.
+midnight-player-keeps = { $player } giữ con { $die }.
+midnight-you-unkeep = Bạn bỏ chọn con { $die }.
+midnight-player-unkeeps = { $player } bỏ chọn con { $die }.
+
+# Trạng thái lượt
+midnight-you-have-kept = Đang giữ: { $kept }. Còn { $remaining } viên chưa gieo.
+midnight-player-has-kept = { $player } đang giữ: { $kept }. Còn { $remaining } viên chưa gieo.
+
+# Ghi điểm
+midnight-you-scored = Bạn được { $score } điểm.
+midnight-scored = { $player } được { $score } điểm.
+midnight-you-disqualified = Bạn không có đủ cặp 1 và 4. Phạm quy!
+midnight-player-disqualified = { $player } không có đủ cặp 1 và 4. Phạm quy!
+
+# Kết quả vòng chơi
+midnight-round-winner = { $player } thắng vòng này!
+midnight-round-tie = Vòng này hòa giữa { $players }.
+midnight-all-disqualified = Tất cả đều phạm quy! Vòng này không ai thắng.
+
+# Người thắng chung cuộc
+midnight-game-winner = { $player } thắng chung cuộc với { $wins } vòng thắng!
+midnight-game-tie = Hòa nhau! { $players } mỗi người thắng { $wins } vòng.
+
+# Tùy chọn
+midnight-set-rounds = Số vòng chơi: { $rounds }
+midnight-enter-rounds = Nhập số vòng chơi:
+midnight-option-changed-rounds = Số vòng chơi đã đặt là { $rounds }
+
+# Lý do hành động bị vô hiệu hóa
+midnight-need-to-roll = Bạn cần gieo xúc xắc trước.
+midnight-no-dice-to-keep = Không có xúc xắc nào để giữ.
+midnight-must-keep-one = Bạn phải giữ ít nhất một viên mỗi lần gieo.
+midnight-must-roll-first = Bạn phải gieo xúc xắc trước.
+midnight-keep-all-first = Bạn phải giữ hết các viên xúc xắc trước khi chốt điểm.

--- a/server/locales/vi/milebymile.ftl
+++ b/server/locales/vi/milebymile.ftl
@@ -1,0 +1,154 @@
+# Thông báo trò chơi Mile by Mile
+# Lưu ý: Các thông báo chung như bắt đầu vòng, bắt đầu lượt, chế độ đội nằm trong games.ftl
+
+# Tên trò chơi
+game-name-milebymile = Đua Xe Ngàn Dặm (Mile by Mile)
+
+# Tùy chọn game
+milebymile-set-distance = Quãng đường đua: { $miles } dặm
+milebymile-enter-distance = Nhập quãng đường (300-3000)
+milebymile-set-winning-score = Điểm chiến thắng: { $score } điểm
+milebymile-enter-winning-score = Nhập điểm chiến thắng (1000-10000)
+milebymile-toggle-perfect-crossing = Yêu cầu về đích chính xác: { $enabled }
+milebymile-toggle-stacking = Cho phép tấn công chồng (stacking): { $enabled }
+milebymile-toggle-reshuffle = Xào lại bài đã bỏ: { $enabled }
+milebymile-toggle-karma = Luật Nghiệp chướng (Karma): { $enabled }
+milebymile-set-rig = Sắp xếp bộ bài (Rigging): { $rig }
+milebymile-select-rig = Chọn tùy chọn sắp xếp bộ bài
+
+# Thông báo thay đổi tùy chọn
+milebymile-option-changed-distance = Quãng đường đua đã đặt là { $miles } dặm.
+milebymile-option-changed-winning = Điểm chiến thắng đã đặt là { $score } điểm.
+milebymile-option-changed-crossing = Yêu cầu về đích chính xác { $enabled }.
+milebymile-option-changed-stacking = Cho phép tấn công chồng { $enabled }.
+milebymile-option-changed-reshuffle = Xào lại bài đã bỏ { $enabled }.
+milebymile-option-changed-karma = Luật Nghiệp chướng { $enabled }.
+milebymile-option-changed-rig = Sắp xếp bộ bài đã đặt là { $rig }.
+
+# Trạng thái
+milebymile-status = { $name }: { $points } điểm, { $miles } dặm, Sự cố: { $problems }, Bảo hộ: { $safeties }
+
+# Hành động bài
+milebymile-no-matching-safety = Bạn không có thẻ bảo hộ tương ứng!
+milebymile-cant-play = Bạn không thể đánh lá { $card } vì { $reason }.
+milebymile-no-card-selected = Chưa chọn lá bài để bỏ.
+milebymile-no-valid-targets = Không có mục tiêu hợp lệ cho thẻ tai nạn này!
+milebymile-you-drew = Bạn đã rút được: { $card }
+milebymile-discards = { $player } bỏ một lá bài.
+milebymile-select-target = Chọn mục tiêu
+
+# Đánh bài quãng đường
+milebymile-plays-distance-individual = { $player } đi được { $distance } dặm, hiện tại đã đi { $total } dặm.
+milebymile-plays-distance-team = { $player } đi được { $distance } dặm; đội của họ đã đi { $total } dặm.
+
+# Hoàn thành chặng đua
+milebymile-journey-complete-perfect-individual = { $player } đã hoàn thành chặng đua với thành tích Về đích hoàn hảo!
+milebymile-journey-complete-perfect-team = Đội { $team } đã hoàn thành chặng đua với thành tích Về đích hoàn hảo!
+milebymile-journey-complete-individual = { $player } đã hoàn thành chặng đua!
+milebymile-journey-complete-team = Đội { $team } đã hoàn thành chặng đua!
+
+# Đánh bài tai nạn
+milebymile-plays-hazard-individual = { $player } đánh lá { $card } vào { $target }.
+milebymile-plays-hazard-team = { $player } đánh lá { $card } vào Đội { $team }.
+
+# Đánh bài Khắc phục/Bảo hộ
+milebymile-plays-card = { $player } đánh lá { $card }.
+milebymile-plays-dirty-trick = { $player } đánh lá { $card } như một Mẹo bẩn (Coup-fourré)!
+
+# Bộ bài
+milebymile-deck-reshuffled = Chồng bài bỏ đã được xào lại vào bộ bài rút.
+
+# Cuộc đua
+milebymile-new-race = Cuộc đua mới bắt đầu!
+milebymile-race-complete = Cuộc đua kết thúc! Đang tính điểm...
+milebymile-earned-points = { $name } kiếm được { $score } điểm trong chặng này: { $breakdown }.
+milebymile-total-scores = Tổng điểm:
+milebymile-team-score = { $name }: { $score } điểm
+
+# Chi tiết điểm số
+milebymile-from-distance = { $miles } từ quãng đường đã đi
+milebymile-from-trip = { $points } từ việc hoàn thành chuyến đi
+milebymile-from-perfect = { $points } từ Về đích hoàn hảo
+milebymile-from-safe = { $points } từ Chuyến đi an toàn
+milebymile-from-shutout = { $points } từ Thắng trắng (đối thủ không đi được dặm nào)
+milebymile-from-safeties = { $points } từ { $count } { $safeties ->
+    [one] thẻ bảo hộ
+   *[other] thẻ bảo hộ
+}
+milebymile-from-all-safeties = { $points } từ việc có đủ 4 thẻ bảo hộ
+milebymile-from-dirty-tricks = { $points } từ { $count } { $tricks ->
+    [one] mẹo bẩn
+   *[other] mẹo bẩn
+}
+
+# Kết thúc game
+milebymile-wins-individual = { $player } thắng trò chơi!
+milebymile-wins-team = Đội { $team } thắng trò chơi! ({ $members })
+milebymile-final-score = Điểm cuối cùng: { $score } điểm
+
+# Thông báo Karma - Xung đột (cả hai đều mất karma)
+milebymile-karma-clash-you-target = Cả bạn và mục tiêu đều bị tẩy chay! Cuộc tấn công bị vô hiệu hóa.
+milebymile-karma-clash-you-attacker = Cả bạn và { $attacker } đều bị tẩy chay! Cuộc tấn công bị vô hiệu hóa.
+milebymile-karma-clash-others = { $attacker } và { $target } đều bị tẩy chay! Cuộc tấn công bị vô hiệu hóa.
+milebymile-karma-clash-your-team = Đội của bạn và mục tiêu đều bị tẩy chay! Cuộc tấn công bị vô hiệu hóa.
+milebymile-karma-clash-target-team = Bạn và Đội { $team } đều bị tẩy chay! Cuộc tấn công bị vô hiệu hóa.
+milebymile-karma-clash-other-teams = Đội { $attacker } và Đội { $target } đều bị tẩy chay! Cuộc tấn công bị vô hiệu hóa.
+
+# Thông báo Karma - Người tấn công bị tẩy chay
+milebymile-karma-shunned-you = Bạn đã bị tẩy chay vì sự hung hăng! Karma của bạn đã mất.
+milebymile-karma-shunned-other = { $player } đã bị tẩy chay vì sự hung hăng của họ!
+milebymile-karma-shunned-your-team = Đội của bạn đã bị tẩy chay vì sự hung hăng! Karma của đội đã mất.
+milebymile-karma-shunned-other-team = Đội { $team } đã bị tẩy chay vì sự hung hăng của họ!
+
+# Giả nhân giả nghĩa (False Virtue)
+milebymile-false-virtue-you = Bạn dùng Giả nhân giả nghĩa và lấy lại Karma!
+milebymile-false-virtue-other = { $player } dùng Giả nhân giả nghĩa và lấy lại Karma!
+milebymile-false-virtue-your-team = Đội bạn dùng Giả nhân giả nghĩa và lấy lại Karma!
+milebymile-false-virtue-other-team = Đội { $team } dùng Giả nhân giả nghĩa và lấy lại Karma!
+
+# Sự cố/Bảo hộ (để hiển thị trạng thái)
+milebymile-none = không có
+
+# Lý do không đánh được bài
+milebymile-reason-not-on-team = bạn không ở trong đội nào
+milebymile-reason-stopped = xe đang bị dừng
+milebymile-reason-has-problem = xe đang gặp sự cố không thể chạy
+milebymile-reason-speed-limit = đang bị giới hạn tốc độ
+milebymile-reason-exceeds-distance = sẽ vượt quá { $miles } dặm
+milebymile-reason-no-targets = không có mục tiêu hợp lệ
+milebymile-reason-no-speed-limit = bạn không bị giới hạn tốc độ
+milebymile-reason-has-right-of-way = thẻ Ưu tiên đường bộ cho phép đi mà không cần Đèn xanh
+milebymile-reason-already-moving = xe đang chạy rồi
+milebymile-reason-must-fix-first = bạn phải sửa lỗi { $problem } trước
+milebymile-reason-has-gas = xe vẫn còn xăng
+milebymile-reason-tires-fine = lốp xe vẫn ổn
+milebymile-reason-no-accident = xe không bị tai nạn
+milebymile-reason-has-safety = bạn đã có thẻ bảo hộ đó rồi
+milebymile-reason-has-karma = bạn vẫn còn Karma
+milebymile-reason-generic = thẻ này không thể đánh lúc này
+
+# Tên lá bài
+milebymile-card-out-of-gas = Hết xăng
+milebymile-card-flat-tire = Xịt lốp
+milebymile-card-accident = Tai nạn
+milebymile-card-speed-limit = Giới hạn tốc độ
+milebymile-card-stop = Dừng lại (Đèn đỏ)
+milebymile-card-gasoline = Xăng
+milebymile-card-spare-tire = Lốp dự phòng
+milebymile-card-repairs = Sửa chữa
+milebymile-card-end-of-limit = Hết giới hạn tốc độ
+milebymile-card-green-light = Đèn xanh
+milebymile-card-extra-tank = Thùng xăng phụ
+milebymile-card-puncture-proof = Lốp chống thủng
+milebymile-card-driving-ace = Tay lái lụa
+milebymile-card-right-of-way = Ưu tiên đường bộ
+milebymile-card-false-virtue = Giả nhân giả nghĩa
+milebymile-card-miles = { $miles } dặm
+
+# Lý do hành động bị vô hiệu hóa
+milebymile-no-dirty-trick-window = Không có cơ hội đánh Mẹo bẩn.
+milebymile-not-your-dirty-trick = Không phải cơ hội đánh Mẹo bẩn của đội bạn.
+milebymile-between-races = Hãy đợi cuộc đua tiếp theo bắt đầu.
+
+# Lỗi xác thực
+milebymile-error-karma-needs-three-teams = Luật Karma yêu cầu ít nhất 3 xe/đội riêng biệt.

--- a/server/locales/vi/ninetynine.ftl
+++ b/server/locales/vi/ninetynine.ftl
@@ -1,0 +1,91 @@
+# Ninety Nine - Bản dịch Tiếng Việt
+# Các thông báo khớp chính xác với bản v10
+
+# Thông tin game
+ninetynine-name = Ninety Nine
+ninetynine-description = Trò chơi bài mà người chơi cố gắng không để tổng điểm vượt quá 99. Người cuối cùng còn trụ lại sẽ thắng!
+
+# Vòng chơi
+ninetynine-round = Vòng { $round }.
+
+# Lượt
+ninetynine-player-turn = Lượt của { $player }.
+
+# Đánh bài - khớp chính xác với bản v10
+ninetynine-you-play = Bạn đánh lá { $card }. Tổng điểm hiện là { $count }.
+ninetynine-player-plays = { $player } đánh lá { $card }. Tổng điểm hiện là { $count }.
+
+# Đảo chiều
+ninetynine-direction-reverses = Đổi chiều chơi!
+
+# Bỏ lượt
+ninetynine-player-skipped = { $player } bị bỏ lượt.
+
+# Mất thẻ (Token) - khớp chính xác với bản v10
+ninetynine-you-lose-tokens = Bạn mất { $amount } { $amount ->
+    [one] thẻ
+   *[other] thẻ
+}.
+ninetynine-player-loses-tokens = { $player } mất { $amount } { $amount ->
+    [one] thẻ
+   *[other] thẻ
+}.
+
+# Loại bỏ
+ninetynine-player-eliminated = { $player } đã bị loại!
+
+# Kết thúc game
+ninetynine-player-wins = { $player } thắng trò chơi!
+
+# Chia bài
+ninetynine-you-deal = Bạn chia bài.
+ninetynine-player-deals = { $player } chia bài.
+
+# Rút bài
+ninetynine-you-draw = Bạn rút lá { $card }.
+ninetynine-player-draws = { $player } rút một lá bài.
+
+# Không có bài hợp lệ
+ninetynine-no-valid-cards = { $player } không có lá bài nào để tổng điểm không vượt quá 99!
+
+# Trạng thái - cho phím C
+ninetynine-current-count = Tổng điểm là { $count }.
+
+# Lựa chọn cho quân Át
+ninetynine-ace-choice = Dùng Át là +1 hay +11?
+ninetynine-ace-add-eleven = Cộng 11
+ninetynine-ace-add-one = Cộng 1
+
+# Lựa chọn cho quân 10
+ninetynine-ten-choice = Dùng 10 là +10 hay -10?
+ninetynine-ten-add = Cộng 10
+ninetynine-ten-subtract = Trừ 10
+
+# Rút bài thủ công
+ninetynine-draw-card = Rút bài
+ninetynine-draw-prompt = Nhấn Space hoặc D để rút bài.
+
+# Tùy chọn
+ninetynine-set-tokens = Số thẻ khởi đầu: { $tokens }
+ninetynine-enter-tokens = Nhập số thẻ khởi đầu:
+ninetynine-option-changed-tokens = Số thẻ khởi đầu đã đặt là { $tokens }.
+ninetynine-set-rules = Biến thể luật: { $rules }
+ninetynine-select-rules = Chọn biến thể luật
+ninetynine-option-changed-rules = Biến thể luật đã đặt là { $rules }.
+ninetynine-set-hand-size = Số bài trên tay: { $size }
+ninetynine-enter-hand-size = Nhập số bài trên tay:
+ninetynine-option-changed-hand-size = Số bài trên tay đã đặt là { $size }.
+ninetynine-set-autodraw = Tự động rút bài: { $enabled }
+ninetynine-option-changed-autodraw = Tự động rút bài: { $enabled }.
+
+# Thông báo biến thể luật (hiện khi bắt đầu game)
+ninetynine-rules-quentin = Luật Quentin C.
+ninetynine-rules-rsgames = Luật RS Games.
+
+# Lựa chọn biến thể luật (hiện trong menu)
+ninetynine-rules-variant-quentin_c = Quentin C
+ninetynine-rules-variant-rs_games = RS Games
+
+# Lý do hành động bị vô hiệu hóa
+ninetynine-choose-first = Bạn cần đưa ra lựa chọn trước.
+ninetynine-draw-first = Bạn cần rút bài trước.

--- a/server/locales/vi/pig.ftl
+++ b/server/locales/vi/pig.ftl
@@ -1,0 +1,31 @@
+# Thông báo trò chơi Pig
+# Lưu ý: Các thông báo chung như bắt đầu vòng, bắt đầu lượt, điểm mục tiêu nằm trong games.ftl
+
+# Thông tin game
+game-name-pig = Pig
+pig-category = Game Xúc Xắc
+
+# Hành động
+pig-roll = Gieo xúc xắc
+pig-bank = Chốt { $points } điểm
+
+# Sự kiện trong game (Riêng cho Pig)
+pig-rolls = { $player } gieo xúc xắc...
+pig-roll-result = Ra { $roll }, tổng điểm lượt này là { $total }
+pig-bust = Ôi không, gieo phải con 1! { $player } mất sạch { $points } điểm.
+pig-bank-action = { $player } quyết định chốt { $points } điểm, nâng tổng điểm lên { $total }
+pig-winner = Chúng ta đã có người chiến thắng, đó là { $player }!
+
+# Tùy chọn riêng cho Pig
+pig-set-min-bank = Điểm chốt tối thiểu: { $points }
+pig-set-dice-sides = Số mặt xúc xắc: { $sides }
+pig-enter-min-bank = Nhập số điểm tối thiểu để được chốt:
+pig-enter-dice-sides = Nhập số mặt của xúc xắc:
+pig-option-changed-min-bank = Điểm chốt tối thiểu đã đổi thành { $points }
+pig-option-changed-dice = Xúc xắc giờ có { $sides } mặt
+
+# Lý do hành động bị vô hiệu hóa
+pig-need-more-points = Bạn cần thêm điểm mới được chốt.
+
+# Lỗi xác thực
+pig-error-min-bank-too-high = Điểm chốt tối thiểu phải thấp hơn điểm mục tiêu thắng.

--- a/server/locales/vi/pirates.ftl
+++ b/server/locales/vi/pirates.ftl
@@ -1,0 +1,143 @@
+# Thông báo trò chơi Pirates of the Lost Seas
+# Lưu ý: Các thông báo chung như bắt đầu vòng, bắt đầu lượt nằm trong games.ftl
+
+# Tên trò chơi
+game-name-pirates = Cướp Biển Vùng Biển Lạc (Pirates of the Lost Seas)
+
+# Bắt đầu và thiết lập
+pirates-welcome = Chào mừng đến với Cướp Biển Vùng Biển Lạc! Hãy dong buồm ra khơi, thu thập đá quý và chiến đấu với những tên cướp biển khác!
+pirates-oceans = Hành trình của bạn sẽ đi qua: { $oceans }
+pirates-gems-placed = { $total } viên đá quý đã nằm rải rác khắp các vùng biển. Hãy tìm tất cả chúng!
+pirates-golden-moon = Trăng Vàng đang lên! Tất cả điểm kinh nghiệm (KN) nhận được sẽ nhân ba trong vòng này!
+
+# Thông báo lượt
+pirates-turn = Lượt của { $player }. Vị trí { $position }
+
+# Hành động di chuyển
+pirates-move-left = Đi sang trái
+pirates-move-right = Đi sang phải
+pirates-move-2-left = Đi 2 ô sang trái
+pirates-move-2-right = Đi 2 ô sang phải
+pirates-move-3-left = Đi 3 ô sang trái
+pirates-move-3-right = Đi 3 ô sang phải
+
+# Thông báo di chuyển
+pirates-move-you = Bạn đi về hướng { $direction } đến vị trí { $position }.
+pirates-move-you-tiles = Bạn đi { $tiles } ô về hướng { $direction } đến vị trí { $position }.
+pirates-move = { $player } đi về hướng { $direction } đến vị trí { $position }.
+pirates-map-edge = Bạn không thể đi xa hơn. Bạn đang ở vị trí { $position }.
+
+# Vị trí và trạng thái
+pirates-check-status = Kiểm tra trạng thái
+pirates-check-position = Kiểm tra vị trí
+pirates-check-moon = Xem độ sáng trăng
+pirates-your-position = Vị trí của bạn: { $position } tại { $ocean }
+pirates-moon-brightness = Trăng Vàng đang sáng { $brightness }%. (Đã thu thập { $collected } trên { $total } viên đá quý).
+pirates-no-golden-moon = Hiện không thấy Trăng Vàng trên bầu trời.
+
+# Thu thập đá quý
+pirates-gem-found-you = Bạn tìm thấy một viên { $gem }! Trị giá { $value } điểm.
+pirates-gem-found = { $player } tìm thấy một viên { $gem }! Trị giá { $value } điểm.
+pirates-all-gems-collected = Tất cả đá quý đã được thu thập!
+
+# Người thắng
+pirates-winner = { $player } thắng với { $score } điểm!
+
+# Menu kỹ năng
+pirates-use-skill = Dùng kỹ năng
+pirates-select-skill = Chọn kỹ năng để dùng
+
+# Chiến đấu - Khởi đầu tấn công
+pirates-cannonball = Bắn pháo
+pirates-no-targets = Không có mục tiêu nào trong phạm vi { $range } ô.
+pirates-attack-you-fire = Bạn bắn một quả pháo vào { $target }!
+pirates-attack-incoming = { $attacker } bắn pháo vào bạn!
+pirates-attack-fired = { $attacker } bắn pháo vào { $defender }!
+
+# Chiến đấu - Gieo xúc xắc
+pirates-attack-roll = Tấn công gieo: { $roll }
+pirates-attack-bonus = Thưởng tấn công: +{ $bonus }
+pirates-defense-roll = Phòng thủ gieo: { $roll }
+pirates-defense-roll-others = { $player } gieo phòng thủ được { $roll }.
+pirates-defense-bonus = Thưởng phòng thủ: +{ $bonus }
+
+# Chiến đấu - Kết quả trúng
+pirates-attack-hit-you = Trúng phóc! Bạn đã bắn trúng { $target }!
+pirates-attack-hit-them = Bạn đã bị { $attacker } bắn trúng!
+pirates-attack-hit = { $attacker } bắn trúng { $defender }!
+
+# Chiến đấu - Kết quả trượt
+pirates-attack-miss-you = Đạn pháo của bạn trượt { $target }.
+pirates-attack-miss-them = Đạn pháo đã trượt bạn!
+pirates-attack-miss = Đạn pháo của { $attacker } trượt { $defender }.
+
+# Chiến đấu - Đẩy lùi
+pirates-push-you = Bạn đẩy { $target } về hướng { $direction } đến vị trí { $position }!
+pirates-push-them = { $attacker } đẩy bạn về hướng { $direction } đến vị trí { $position }!
+pirates-push = { $attacker } đẩy { $defender } về hướng { $direction } từ { $old_pos } đến { $new_pos }.
+
+# Chiến đấu - Cướp đá quý
+pirates-steal-attempt = { $attacker } định cướp đá quý!
+pirates-steal-rolls = Gieo cướp: { $steal } đấu với thủ: { $defend }
+pirates-steal-success-you = Bạn đã cướp được viên { $gem } từ { $target }!
+pirates-steal-success-them = { $attacker } đã cướp viên { $gem } của bạn!
+pirates-steal-success = { $attacker } cướp được viên { $gem } từ { $defender }!
+pirates-steal-failed = Cướp thất bại!
+
+# KN và Lên cấp
+pirates-xp-gained = +{ $xp } KN
+pirates-level-up = { $player } đã lên cấp { $level }!
+pirates-level-up-you = Bạn đã lên cấp { $level }!
+pirates-level-up-multiple = { $player } tăng { $levels } cấp! Hiện là cấp { $level }!
+pirates-level-up-multiple-you = Bạn tăng { $levels } cấp! Hiện là cấp { $level }!
+pirates-skills-unlocked = { $player } mở khóa kỹ năng mới: { $skills }.
+pirates-skills-unlocked-you = Bạn mở khóa kỹ năng mới: { $skills }.
+
+# Kích hoạt kỹ năng
+pirates-skill-activated = { $player } kích hoạt { $skill }!
+pirates-buff-expired = Hiệu ứng { $skill } của { $player } đã hết.
+
+# Kỹ năng Tay Kiếm (Sword Fighter)
+pirates-sword-fighter-activated = Kỹ năng "Tay Kiếm" kích hoạt! +4 tấn công trong { $turns } lượt.
+
+# Kỹ năng Đẩy (Push - tăng thủ)
+pirates-push-activated = Kỹ năng "Đẩy" kích hoạt! +3 phòng thủ trong { $turns } lượt.
+
+# Kỹ năng Thuyền Trưởng Tài Ba (Skilled Captain)
+pirates-skilled-captain-activated = Kỹ năng "Thuyền Trưởng Tài Ba" kích hoạt! +2 công và +2 thủ trong { $turns } lượt.
+
+# Kỹ năng Hủy Diệt Kép (Double Devastation)
+pirates-double-devastation-activated = Kỹ năng "Hủy Diệt Kép" kích hoạt! Tầm bắn tăng lên 10 ô trong { $turns } lượt.
+
+# Kỹ năng Chiến Hạm (Battleship)
+pirates-battleship-activated = Kỹ năng "Chiến Hạm" kích hoạt! Bạn được bắn hai phát trong lượt này!
+pirates-battleship-no-targets = Không có mục tiêu cho phát bắn thứ { $shot }.
+pirates-battleship-shot = Đang bắn phát thứ { $shot }...
+
+# Kỹ năng Cổng Dịch Chuyển (Portal)
+pirates-portal-no-ships = Không thấy tàu nào khác để dịch chuyển tới.
+pirates-portal-fizzle = Cổng dịch chuyển của { $player } bị xịt, không có đích đến.
+pirates-portal-success = { $player } dịch chuyển đến vùng { $ocean } tại vị trí { $position }!
+
+# Kỹ năng Tầm Ngọc (Gem Seeker)
+pirates-gem-seeker-reveal = Biển cả thì thầm về một viên { $gem } tại vị trí { $position }. (Còn { $uses } lần dùng)
+
+# Yêu cầu cấp độ
+pirates-requires-level-15 = Cần cấp 15
+pirates-requires-level-150 = Cần cấp 150
+
+# Tùy chọn hệ số KN
+pirates-set-combat-xp-multiplier = Hệ số KN chiến đấu: { $combat_multiplier }
+pirates-enter-combat-xp-multiplier = Điểm kinh nghiệm cho chiến đấu
+pirates-set-find-gem-xp-multiplier = Hệ số KN tìm ngọc: { $find_gem_multiplier }
+pirates-enter-find-gem-xp-multiplier = Điểm kinh nghiệm khi tìm thấy ngọc
+
+# Tùy chọn cướp ngọc
+pirates-set-gem-stealing = Cướp đá quý: { $mode }
+pirates-select-gem-stealing = Chọn chế độ cướp đá quý
+pirates-option-changed-stealing = Chế độ cướp đá quý đã đặt là { $mode }.
+
+# Các chế độ cướp ngọc
+pirates-stealing-with-bonus = Có cộng điểm gieo
+pirates-stealing-no-bonus = Không cộng điểm gieo
+pirates-stealing-disabled = Tắt

--- a/server/locales/vi/poker.ftl
+++ b/server/locales/vi/poker.ftl
@@ -1,0 +1,107 @@
+# Thông báo chung cho Poker
+
+poker-fold = Bỏ bài
+poker-call = Theo
+poker-check = Xem
+poker-raise = Tố
+poker-all-in = Tất tay
+poker-enter-raise = Nhập số tiền tố
+
+poker-check-pot = Xem tổng Gà (Pot)
+poker-check-bet = Số tiền cần để Theo
+poker-check-min-raise = Mức tố tối thiểu
+poker-check-log = Nhật ký ván đấu
+poker-check-hand-players = Người chơi trong ván
+poker-check-turn-timer = Đồng hồ lượt
+poker-check-blind-timer = Đồng hồ tăng mù
+poker-check-button = Ai đang giữ Nút (Button)
+poker-check-dealer = Ai là người chia bài
+poker-check-position = Vị trí của bạn
+
+poker-read-hand = Xem bài tẩy
+poker-read-table = Xem bài chung
+poker-hand-value = Giá trị bài
+poker-read-card = Đọc lá thứ { $index }
+poker-dealt-cards = Bạn được chia { $cards }.
+poker-flop = Vòng Flop: { $cards }.
+poker-turn = Vòng Turn: { $card }.
+poker-river = Vòng River: { $card }.
+
+poker-pot-total = { $amount } chip trong Gà.
+poker-pot-main = Gà chính: { $amount } chip.
+poker-pot-side = Gà phụ { $index }: { $amount } chip.
+poker-to-call = Bạn cần { $amount } chip để Theo.
+poker-min-raise = Tố tối thiểu { $amount } chip.
+
+poker-player-folds = { $player } bỏ bài.
+poker-player-checks = { $player } xem.
+poker-player-calls = { $player } theo { $amount } chip.
+poker-player-raises = { $player } tố { $amount } chip.
+poker-player-all-in = { $player } tất tay với { $amount } chip.
+
+poker-player-wins-pot = { $player } thắng { $amount } chip.
+poker-player-wins-pot-hand = { $player } thắng { $amount } chip với { $cards } ({ $hand }).
+poker-players-split-pot = { $players } chia gà { $amount } chip với { $hand }.
+poker-player-wins-game = { $player } thắng trò chơi.
+
+poker-showdown = Ngửa bài.
+
+poker-timer-disabled = Đồng hồ lượt đang tắt.
+poker-timer-remaining = Còn { $seconds } giây.
+poker-blind-timer-disabled = Đồng hồ tăng mù đang tắt.
+poker-blind-timer-remaining = { $seconds } giây nữa sẽ tăng mù.
+poker-blind-timer-remaining-ms = { $minutes } phút { $seconds } giây nữa sẽ tăng mù.
+poker-blinds-raise-next-hand = Tiền mù sẽ tăng ở ván sau.
+
+poker-button-is = Nút đang ở chỗ { $player }.
+poker-dealer-is = Người chia bài là { $player }.
+poker-position-seat = Bạn ngồi sau Nút { $position } ghế.
+poker-position-seats = Bạn ngồi sau Nút { $position } ghế.
+poker-position-button = Bạn đang giữ Nút.
+poker-position-dealer = Bạn ngồi sau người chia bài { $position } ghế.
+poker-show-hand = { $player } lật { $cards } ({ $hand }).
+poker-blinds-players = Mù nhỏ: { $sb }. Mù lớn: { $bb }.
+poker-reveal-only-showdown = Bạn chỉ được lật bài khi Ngửa bài cuối ván.
+
+poker-reveal-both = Lật cả hai lá tẩy
+poker-reveal-first = Lật lá tẩy thứ nhất
+poker-reveal-second = Lật lá tẩy thứ hai
+
+poker-raise-cap-reached = Đã đạt giới hạn số lần tố trong vòng này.
+poker-raise-too-small = Tố tối thiểu là { $amount } chip.
+poker-hand-players-none = Không có người chơi trong ván.
+poker-hand-players-one = { $count } người chơi: { $names }.
+poker-hand-players = { $count } người chơi: { $names }.
+poker-raise-too-large = Bạn không thể tố nhiều hơn số chip mình đang có.
+
+poker-log-empty = Chưa có hành động nào.
+poker-log-fold = { $player } đã bỏ bài
+poker-log-check = { $player } đã xem
+poker-log-call = { $player } đã theo { $amount }
+poker-log-raise = { $player } đã tố { $amount }
+poker-log-all-in = { $player } đã tất tay { $amount }
+
+poker-table-cards = Bài chung: { $cards }.
+poker-your-hand = Bài trên tay: { $cards }.
+
+# Nhãn lựa chọn thời gian
+poker-timer-5 = 5 giây
+poker-timer-10 = 10 giây
+poker-timer-15 = 15 giây
+poker-timer-20 = 20 giây
+poker-timer-30 = 30 giây
+poker-timer-45 = 45 giây
+poker-timer-60 = 60 giây
+poker-timer-90 = 90 giây
+poker-timer-unlimited = Không giới hạn
+
+poker-blind-timer-unlimited = Không giới hạn
+poker-blind-timer-5 = 5 phút
+poker-blind-timer-10 = 10 phút
+poker-blind-timer-15 = 15 phút
+poker-blind-timer-20 = 20 phút
+poker-blind-timer-30 = 30 phút
+
+poker-raise-no-limit = Không giới hạn (No Limit)
+poker-raise-pot-limit = Giới hạn theo Gà (Pot Limit)
+poker-raise-double-pot = Giới hạn gấp đôi Gà

--- a/server/locales/vi/scopa.ftl
+++ b/server/locales/vi/scopa.ftl
@@ -1,0 +1,76 @@
+# Thông báo trò chơi Scopa
+# Lưu ý: Các thông báo chung như bắt đầu vòng, bắt đầu lượt, điểm mục tiêu, chế độ đội nằm trong games.ftl
+
+# Tên trò chơi
+game-name-scopa = Scopa
+
+# Sự kiện trong game
+scopa-initial-table = Bài trên bàn: { $cards }
+scopa-no-initial-table = Không có bài trên bàn khi bắt đầu.
+scopa-you-collect = Bạn ăn { $cards } bằng lá { $card }
+scopa-player-collects = { $player } ăn { $cards } bằng lá { $card }
+scopa-you-put-down = Bạn hạ xuống lá { $card }.
+scopa-player-puts-down = { $player } hạ xuống lá { $card }.
+scopa-scopa-suffix =  - SCOPA!
+scopa-clear-table-suffix = , quét sạch bàn.
+scopa-remaining-cards = { $player } nhận số bài còn lại trên bàn.
+scopa-scoring-round = Vòng tính điểm...
+scopa-most-cards = { $player } được 1 điểm vì nhiều bài nhất ({ $count } lá).
+scopa-most-cards-tie = Số lượng bài bằng nhau - không ai có điểm.
+scopa-most-diamonds = { $player } được 1 điểm vì nhiều Rô nhất ({ $count } lá).
+scopa-most-diamonds-tie = Số lượng Rô bằng nhau - không ai có điểm.
+scopa-seven-diamonds = { $player } được 1 điểm vì có lá 7 Rô.
+scopa-seven-diamonds-multi = { $player } được 1 điểm vì có nhiều 7 Rô nhất ({ $count } × 7 Rô).
+scopa-seven-diamonds-tie = Số lượng 7 Rô bằng nhau - không ai có điểm.
+scopa-most-sevens = { $player } được 1 điểm vì nhiều quân 7 nhất ({ $count } quân).
+scopa-most-sevens-tie = Số lượng quân 7 bằng nhau - không ai có điểm.
+scopa-round-scores = Điểm vòng này:
+scopa-round-score-line = { $player }: +{ $round_score } (tổng: { $total_score })
+scopa-table-empty = Không có lá bài nào trên bàn.
+scopa-no-such-card = Không có lá bài nào ở vị trí đó.
+scopa-captured-count = Bạn đã ăn được { $count } lá
+
+# Hành động xem
+scopa-view-table = Xem bàn
+scopa-view-captured = Xem bài đã ăn
+
+# Tùy chọn riêng cho Scopa
+scopa-enter-target-score = Nhập điểm mục tiêu (1-121)
+scopa-set-cards-per-deal = Số lá mỗi lần chia: { $cards }
+scopa-enter-cards-per-deal = Nhập số lá mỗi lần chia (1-10)
+scopa-set-decks = Số lượng bộ bài: { $decks }
+scopa-enter-decks = Nhập số lượng bộ bài (1-6)
+scopa-toggle-escoba = Chế độ Escoba (tổng bằng 15): { $enabled }
+scopa-toggle-hints = Gợi ý nước ăn bài: { $enabled }
+scopa-set-mechanic = Cơ chế Scopa: { $mechanic }
+scopa-select-mechanic = Chọn cơ chế Scopa
+scopa-toggle-instant-win = Thắng ngay khi được Scopa: { $enabled }
+scopa-toggle-team-scoring = Gộp bài cả đội để tính điểm: { $enabled }
+scopa-toggle-inverse = Chế độ Đảo ngược (đạt điểm mục tiêu = bị loại): { $enabled }
+
+# Thông báo thay đổi tùy chọn
+scopa-option-changed-cards = Số lá mỗi lần chia đã đặt là { $cards }.
+scopa-option-changed-decks = Số lượng bộ bài đã đặt là { $decks }.
+scopa-option-changed-escoba = Chế độ Escoba { $enabled }.
+scopa-option-changed-hints = Gợi ý nước ăn bài { $enabled }.
+scopa-option-changed-mechanic = Cơ chế Scopa đã đặt là { $mechanic }.
+scopa-option-changed-instant = Thắng ngay khi được Scopa { $enabled }.
+scopa-option-changed-team-scoring = Gộp bài cả đội để tính điểm { $enabled }.
+scopa-option-changed-inverse = Chế độ Đảo ngược { $enabled }.
+
+# Các lựa chọn cơ chế Scopa
+scopa-mechanic-normal = Bình thường
+scopa-mechanic-no_scopas = Không tính điểm Scopa
+scopa-mechanic-only_scopas = Chỉ tính điểm Scopa
+
+# Lý do hành động bị vô hiệu hóa
+scopa-timer-not-active = Đồng hồ vòng chơi không hoạt động.
+
+# Lỗi xác thực
+scopa-error-not-enough-cards = Không đủ bài trong { $decks } { $decks ->
+    [one] bộ bài
+   *[other] bộ bài
+} cho { $players } { $players ->
+    [one] người chơi
+   *[other] người chơi
+} với { $cards_per_deal } lá mỗi người. (Cần { $cards_per_deal } × { $players } = { $cards_needed } lá, nhưng chỉ có { $total_cards }.)

--- a/server/locales/vi/threes.ftl
+++ b/server/locales/vi/threes.ftl
@@ -1,0 +1,44 @@
+# Thông báo trò chơi xúc xắc Threes
+
+# Thông tin game
+game-name-threes = Threes
+threes-category = Game Xúc Xắc
+
+# Hành động
+threes-roll = Gieo xúc xắc
+threes-bank = Chốt và kết thúc lượt
+threes-check-hand = Kiểm tra xúc xắc
+
+# Gieo xúc xắc
+threes-you-rolled = Bạn gieo được: { $dice }
+threes-player-rolled = { $player } gieo được: { $dice }
+threes-must-keep = Bạn phải giữ lại ít nhất một viên trước khi gieo tiếp.
+
+# Trạng thái xúc xắc
+threes-no-dice-yet = Bạn chưa gieo xúc xắc.
+threes-your-dice = Xúc xắc của bạn: { $dice }
+
+# Ghi điểm
+threes-you-scored = Lượt này bạn được { $score } điểm.
+threes-scored = Lượt này { $player } được { $score } điểm.
+threes-you-shot-moon = Bắn rụng mặt trăng! Bạn được -30 điểm!
+threes-shot-moon = { $player } đã bắn rụng mặt trăng và được -30 điểm!
+
+# Luồng vòng chơi
+threes-round-start = Vòng { $round } trên { $total }.
+threes-round-scores = Điểm vòng { $round }: { $scores }
+
+# Kết thúc game
+threes-winner = { $player } thắng với { $score } điểm!
+threes-tie = { $players } hòa nhau với { $score } điểm!
+
+# Tùy chọn
+threes-set-rounds = Số vòng: { $rounds }
+threes-enter-rounds = Nhập số vòng chơi:
+threes-option-changed-rounds = Số vòng chơi đã đặt là { $rounds }.
+
+# Lý do hành động bị vô hiệu hóa
+threes-must-bank = Bạn buộc phải chốt ngay.
+threes-roll-first = Bạn cần gieo xúc xắc trước.
+threes-keep-all-first = Bạn phải giữ tất cả xúc xắc trước khi chốt.
+threes-last-die = Đây là viên xúc xắc cuối cùng.

--- a/server/locales/vi/tossup.ftl
+++ b/server/locales/vi/tossup.ftl
@@ -1,0 +1,56 @@
+# Thông báo trò chơi Toss Up
+# Lưu ý: Các thông báo chung như bắt đầu vòng, bắt đầu lượt, điểm mục tiêu nằm trong games.ftl
+
+# Thông tin game
+game-name-tossup = Toss Up
+tossup-category = Game Xúc Xắc
+
+# Hành động
+tossup-roll-first = Gieo { $count } viên
+tossup-roll-remaining = Gieo tiếp { $count } viên còn lại
+tossup-bank = Chốt { $points } điểm
+
+# Sự kiện trong game
+tossup-turn-start = Lượt của { $player }. Điểm: { $score }
+tossup-you-roll = Bạn gieo được: { $results }.
+tossup-player-rolls = { $player } gieo được: { $results }.
+
+# Trạng thái lượt
+tossup-you-have-points = Điểm lượt này: { $turn_points }. Còn lại: { $dice_count } viên.
+tossup-player-has-points = { $player } được { $turn_points } điểm lượt này. Còn { $dice_count } viên.
+
+# Xúc xắc mới (khi gieo hết số viên hiện có)
+tossup-you-get-fresh = Hết xúc xắc! Nhận { $count } viên mới.
+tossup-player-gets-fresh = { $player } nhận { $count } viên mới.
+
+# Cháy điểm (Bust)
+tossup-you-bust = Cháy điểm! Bạn mất { $points } điểm của lượt này.
+tossup-player-busts = { $player } bị cháy điểm và mất { $points } điểm!
+
+# Chốt điểm
+tossup-you-bank = Bạn chốt { $points } điểm. Tổng điểm: { $total }.
+tossup-player-banks = { $player } chốt { $points } điểm. Tổng điểm: { $total }.
+
+# Người thắng
+tossup-winner = { $player } thắng với { $score } điểm!
+tossup-tie-tiebreaker = Hòa giữa { $players }! Vào vòng phân định thắng thua!
+
+# Tùy chọn
+tossup-set-rules-variant = Biến thể luật: { $variant }
+tossup-select-rules-variant = Chọn biến thể luật:
+tossup-option-changed-rules = Biến thể luật đã đổi thành { $variant }
+
+tossup-set-starting-dice = Số xúc xắc khởi đầu: { $count }
+tossup-enter-starting-dice = Nhập số lượng xúc xắc khởi đầu:
+tossup-option-changed-dice = Số xúc xắc khởi đầu đã đổi thành { $count }
+
+# Các biến thể luật
+tossup-rules-standard = Tiêu chuẩn
+tossup-rules-playpalace = PlayPalace
+
+# Giải thích luật
+tossup-rules-standard-desc = Mỗi viên có 3 mặt Xanh, 2 Vàng, 1 Đỏ. Cháy điểm nếu không có mặt Xanh nào và có ít nhất một mặt Đỏ.
+tossup-rules-playpalace-desc = Phân bố các mặt đều nhau. Cháy điểm nếu tất cả xúc xắc đều ra màu Đỏ.
+
+# Lý do hành động bị vô hiệu hóa
+tossup-need-points = Bạn cần có điểm mới được chốt.

--- a/server/locales/vi/tradeoff.ftl
+++ b/server/locales/vi/tradeoff.ftl
@@ -1,0 +1,70 @@
+# Thông báo trò chơi Tradeoff
+
+# Thông tin game
+game-name-tradeoff = Tradeoff
+
+# Luồng vòng chơi và lượt
+tradeoff-round-start = Vòng { $round }.
+tradeoff-iteration = Ván { $iteration } trên 3.
+
+# Giai đoạn 1: Trao đổi
+tradeoff-you-rolled = Bạn gieo được: { $dice }.
+tradeoff-toggle-trade = { $value } ({ $status })
+tradeoff-trade-status-trading = đổi
+tradeoff-trade-status-keeping = giữ
+tradeoff-confirm-trades = Xác nhận đổi ({ $count } viên)
+tradeoff-keeping = Đang giữ con { $value }.
+tradeoff-trading = Đang đổi con { $value }.
+tradeoff-player-traded = { $player } đã đổi: { $dice }.
+tradeoff-player-traded-none = { $player } giữ lại toàn bộ xúc xắc.
+
+# Giai đoạn 2: Lấy từ kho
+tradeoff-your-turn-take = Đến lượt bạn lấy một viên từ kho.
+tradeoff-take-die = Lấy con { $value } (còn { $remaining } viên)
+tradeoff-you-take = Bạn lấy một con { $value }.
+tradeoff-player-takes = { $player } lấy một con { $value }.
+
+# Giai đoạn 3: Tính điểm
+tradeoff-player-scored = { $player } ({ $points } điểm): { $sets }.
+tradeoff-no-sets = { $player }: không có bộ nào.
+
+# Mô tả các bộ (ngắn gọn)
+tradeoff-set-triple = bộ ba { $value }
+tradeoff-set-group = nhóm { $value }
+tradeoff-set-mini-straight = sảnh nhỏ { $low }-{ $high }
+tradeoff-set-double-triple = hai bộ ba ({ $v1 } và { $v2 })
+tradeoff-set-straight = sảnh { $low }-{ $high }
+tradeoff-set-double-group = hai nhóm ({ $v1 } và { $v2 })
+tradeoff-set-all-groups = toàn bộ là nhóm
+tradeoff-set-all-triplets = toàn bộ là bộ ba
+
+# Kết thúc vòng
+tradeoff-round-scores = Điểm vòng { $round }:
+tradeoff-score-line = { $player }: +{ $round_points } (tổng: { $total })
+tradeoff-leader = { $player } dẫn đầu với { $score } điểm.
+
+# Kết thúc game
+tradeoff-winner = { $player } thắng với { $score } điểm!
+tradeoff-winners-tie = Hòa nhau! { $players } hòa với { $score } điểm!
+
+# Kiểm tra trạng thái
+tradeoff-view-hand = Xem xúc xắc trên tay
+tradeoff-view-pool = Xem kho
+tradeoff-view-players = Xem người chơi
+tradeoff-hand-display = Trên tay bạn ({ $count } viên): { $dice }
+tradeoff-pool-display = Kho ({ $count } viên): { $dice }
+tradeoff-player-info = { $player }: { $hand }. Đã đổi: { $traded }.
+tradeoff-player-info-no-trade = { $player }: { $hand }. Không đổi gì.
+
+# Thông báo lỗi
+tradeoff-not-trading-phase = Không phải giai đoạn trao đổi.
+tradeoff-not-taking-phase = Không phải giai đoạn lấy từ kho.
+tradeoff-already-confirmed = Đã xác nhận rồi.
+tradeoff-no-die = Không có xúc xắc để chọn.
+tradeoff-no-more-takes = Không còn lượt lấy.
+tradeoff-not-in-pool = Viên này không có trong kho.
+
+# Tùy chọn
+tradeoff-set-target = Điểm mục tiêu: { $score }
+tradeoff-enter-target = Nhập điểm mục tiêu:
+tradeoff-option-changed-target = Điểm mục tiêu đã đặt là { $score }.

--- a/server/locales/vi/yahtzee.ftl
+++ b/server/locales/vi/yahtzee.ftl
@@ -1,0 +1,94 @@
+# Thông báo trò chơi Yahtzee
+
+# Thông tin game
+game-name-yahtzee = Yahtzee
+
+# Hành động - Gieo xúc xắc
+yahtzee-roll = Gieo lại (còn { $count } lần)
+yahtzee-roll-all = Gieo xúc xắc
+
+# Các mục điểm Phần trên
+yahtzee-score-ones = Mặt 1 được { $points } điểm
+yahtzee-score-twos = Mặt 2 được { $points } điểm
+yahtzee-score-threes = Mặt 3 được { $points } điểm
+yahtzee-score-fours = Mặt 4 được { $points } điểm
+yahtzee-score-fives = Mặt 5 được { $points } điểm
+yahtzee-score-sixes = Mặt 6 được { $points } điểm
+
+# Các mục điểm Phần dưới
+yahtzee-score-three-kind = Bộ ba được { $points } điểm
+yahtzee-score-four-kind = Tứ quý được { $points } điểm
+yahtzee-score-full-house = Cù lũ được { $points } điểm
+yahtzee-score-small-straight = Sảnh nhỏ được { $points } điểm
+yahtzee-score-large-straight = Sảnh lớn được { $points } điểm
+yahtzee-score-yahtzee = Yahtzee được { $points } điểm
+yahtzee-score-chance = Cơ hội được { $points } điểm
+
+# Sự kiện trong game
+yahtzee-you-rolled = Bạn gieo được: { $dice }. Còn { $remaining } lần gieo.
+yahtzee-player-rolled = { $player } gieo được: { $dice }. Còn { $remaining } lần gieo.
+
+# Thông báo ghi điểm
+yahtzee-you-scored = Bạn ghi { $points } điểm vào mục { $category }.
+yahtzee-player-scored = { $player } ghi { $points } vào mục { $category }.
+
+# Thưởng Yahtzee
+yahtzee-you-bonus = Thưởng Yahtzee! +100 điểm
+yahtzee-player-bonus = { $player } nhận thưởng Yahtzee! +100 điểm
+
+# Thưởng Phần trên
+yahtzee-you-upper-bonus = Thưởng phần trên! +35 điểm (đạt { $total } điểm phần trên)
+yahtzee-player-upper-bonus = { $player } nhận thưởng phần trên! +35 điểm
+yahtzee-you-upper-bonus-missed = Bạn trượt mất thưởng phần trên (đạt { $total }, cần 63).
+yahtzee-player-upper-bonus-missed = { $player } trượt mất thưởng phần trên.
+
+# Chế độ ghi điểm
+yahtzee-choose-category = Chọn mục để ghi điểm.
+yahtzee-continuing = Tiếp tục lượt.
+
+# Kiểm tra trạng thái
+yahtzee-check-scoresheet = Xem bảng điểm
+yahtzee-view-dice = Kiểm tra xúc xắc
+yahtzee-your-dice = Xúc xắc của bạn: { $dice }.
+yahtzee-your-dice-kept = Xúc xắc của bạn: { $dice }. Đang giữ: { $kept }
+yahtzee-not-rolled = Bạn chưa gieo xúc xắc.
+
+# Hiển thị bảng điểm
+yahtzee-scoresheet-header = === Bảng điểm của { $player } ===
+yahtzee-scoresheet-upper = Phần trên:
+yahtzee-scoresheet-lower = Phần dưới:
+yahtzee-scoresheet-category-filled = { $category }: { $points }
+yahtzee-scoresheet-category-open = { $category }: -
+yahtzee-scoresheet-upper-total-bonus = Tổng Phần trên: { $total } (THƯỞNG: +35)
+yahtzee-scoresheet-upper-total-needed = Tổng Phần trên: { $total } (cần thêm { $needed } để thưởng)
+yahtzee-scoresheet-yahtzee-bonus = Thưởng Yahtzee: { $count } x 100 = { $total }
+yahtzee-scoresheet-grand-total = TỔNG ĐIỂM: { $total }
+
+# Tên các mục (để thông báo)
+yahtzee-category-ones = Mặt 1
+yahtzee-category-twos = Mặt 2
+yahtzee-category-threes = Mặt 3
+yahtzee-category-fours = Mặt 4
+yahtzee-category-fives = Mặt 5
+yahtzee-category-sixes = Mặt 6
+yahtzee-category-three-kind = Bộ ba
+yahtzee-category-four-kind = Tứ quý
+yahtzee-category-full-house = Cù lũ
+yahtzee-category-small-straight = Sảnh nhỏ
+yahtzee-category-large-straight = Sảnh lớn
+yahtzee-category-yahtzee = Yahtzee
+yahtzee-category-chance = Cơ hội
+
+# Kết thúc game
+yahtzee-winner = { $player } thắng với { $score } điểm!
+yahtzee-winners-tie = Hòa nhau! { $players } đều được { $score } điểm!
+
+# Tùy chọn
+yahtzee-set-rounds = Số ván đấu: { $rounds }
+yahtzee-enter-rounds = Nhập số ván đấu (1-10):
+yahtzee-option-changed-rounds = Số ván đấu đã đặt là { $rounds }.
+
+# Lý do hành động bị vô hiệu hóa
+yahtzee-no-rolls-left = Bạn không còn lượt gieo nào.
+yahtzee-roll-first = Bạn cần gieo xúc xắc trước.
+yahtzee-category-filled = Mục này đã được ghi điểm rồi.


### PR DESCRIPTION
Added new Vietnamese locale files for Age of Heroes, Chaos Bear, Farkle, Five Card Draw, general game messages, Hold'em, Left Right Center, Light Turret, 1-4-24, Mile by Mile, Ninety Nine, Pig, Pirates of the Lost Seas, Shared Poker, Scopa, Toss Up, Threes, Tradeoff, Yahtzee, and main interface. These files provide full in-game translations and options for each respective game.