### PR TITLE
Added F2/Shift F2 for Who's Online, First Attempt

### DIFF
--- a/client/ui/main_window.py
+++ b/client/ui/main_window.py
@@ -344,6 +344,8 @@ class MainWindow(wx.Frame):
     def on_list_online_with_games(self, event):
         """Handle Shift+F2 to request online users with game info."""
         if self.connected:
+            if self.current_menu_id == "online_users":
+                return
             self.network.send_packet({"type": "list_online_with_games"})
 
     def on_server_pong(self, packet):

--- a/server/core/server.py
+++ b/server/core/server.py
@@ -2201,6 +2201,7 @@ class Server:
             items,
             multiletter=False,
             escape_behavior=EscapeBehavior.SELECT_LAST,
+            position=0,
         )
         self._user_states[user.username] = {
             "menu": "online_users",
@@ -2241,10 +2242,15 @@ class Server:
             return
 
         online = self._get_online_usernames()
-        if online:
-            user.speak(f"Online: {', '.join(online)}")
+        count = len(online)
+        if count == 0:
+            user.speak_l("online-users-none")
+            return
+        users_str = Localization.format_list_and(user.locale, online)
+        if count == 1:
+            user.speak_l("online-users-one", users=users_str)
         else:
-            user.speak("No users online.")
+            user.speak_l("online-users-many", count=count, users=users_str)
 
     async def _handle_list_online_with_games(self, client: ClientConnection) -> None:
         """Handle request for online users list with game info."""

--- a/server/locales/en/main.ftl
+++ b/server/locales/en/main.ftl
@@ -70,6 +70,9 @@ goodbye = Goodbye!
 # User presence announcements
 user-online = { $player } came online.
 user-offline = { $player } went offline.
+online-users-none = No users online.
+online-users-one = 1 user: { $users }
+online-users-many = { $count } users: { $users }
 
 # Options
 language = Language

--- a/server/locales/pl/main.ftl
+++ b/server/locales/pl/main.ftl
@@ -68,6 +68,9 @@ goodbye = pa!
 # User presence announcements
 user-online = { $player } jest online.
 user-offline = { $player } poszedł offline
+online-users-none = Brak użytkowników online.
+online-users-one = 1 użytkownik: { $users }
+online-users-many = { $count } użytkowników: { $users }
 
 # Options
 language = Język

--- a/server/locales/pt/main.ftl
+++ b/server/locales/pt/main.ftl
@@ -68,6 +68,9 @@ goodbye = Até logo!
 # Anúncios de presença do usuário
 user-online = { $player } entrou online.
 user-offline = { $player } saiu.
+online-users-none = Nenhum usuário online.
+online-users-one = 1 usuário: { $users }
+online-users-many = { $count } usuários: { $users }
 
 # Opções
 language = Idioma

--- a/server/locales/vi/main.ftl
+++ b/server/locales/vi/main.ftl
@@ -74,6 +74,9 @@ goodbye = Tạm biệt!
 # Thông báo trạng thái người dùng
 user-online = { $player } vừa online.
 user-offline = { $player } đã offline.
+online-users-none = Không có người dùng trực tuyến.
+online-users-one = 1 người dùng: { $users }
+online-users-many = { $count } người dùng: { $users }
 
 # Tùy chọn
 language = Ngôn ngữ

--- a/server/locales/zh/main.ftl
+++ b/server/locales/zh/main.ftl
@@ -68,6 +68,9 @@ goodbye = 再见！
 # 用户在线状态公告
 user-online = { $player } 上线了。
 user-offline = { $player } 下线了。
+online-users-none = 没有用户在线。
+online-users-one = 1 位用户: { $users }
+online-users-many = { $count } 位用户: { $users }
 
 # 设置
 language = 语言

--- a/server/tests/test_online_users.py
+++ b/server/tests/test_online_users.py
@@ -43,7 +43,7 @@ async def test_list_online_users_speaks_sorted_list() -> None:
     client = DummyClient("Alice")
     await server._handle_list_online(client)
 
-    assert alice.messages[-1].data["text"] == "Online: Alice, Bob"
+    assert alice.messages[-1].data["text"] == "2 users: Alice and Bob"
 
 
 def test_online_users_menu_formats_game_names() -> None:


### PR DESCRIPTION
Motivation
• Provide a global, non-conflicting shortcut to view who is online and optionally which game they're in with online-list hotkeys to F2/Shift+F2
• Surface a readable list/menu of online users from the server and allow the UI to restore the previous menu state after viewing the list.
Description
• Client: bound F2 and Shift+F2 to on_list_online and on_list_online_with_games,
• Server: accept list_online and list_online_with_games packets in _on_client_message and implemented helpers �_get_online_usernames� (sorted names), �_format_online_users_lines� (format lines with game names), �_show_online_users_menu� and �_restore_previous_menu� to present a read-only menu and restore prior menu state, plus handlers �_handle_list_online� and �_handle_list_online_with_games� to speak or display the list.
• Tests: added server/tests/test_online_users.py with test_list_online_users_speaks_sorted_list and test_online_users_menu_formats_game_names to verify spoken sorted output and menu formatting with game names.

Note, open to other ideas or different ways to communicate with server.