### PR TITLE
Add pytest slow marker flag

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -31,6 +31,9 @@ testpaths = ["tests"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 pythonpath = [".."]
+markers = [
+    "slow: marks tests that require --runslow to execute",
+]
 
 
 [tool.hatch.build.targets.wheel]

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -13,6 +13,19 @@ from server.messages.localization import Localization
 _locales_dir = Path(__file__).parent.parent / "locales"
 Localization.init(_locales_dir)
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--runslow",
+        action="store_true",
+        default=False,
+        help="run tests marked as slow",
+    )
+
+
+def pytest_runtest_setup(item):
+    if "slow" in item.keywords and not item.config.getoption("--runslow"):
+        pytest.skip("use --runslow to run slow tests")
+
 
 @pytest.fixture
 def mock_user():


### PR DESCRIPTION
## Summary
- register a shared pytest slow marker so tests can opt in
- expose a --runslow option and skip marked tests unless the flag is set
