### PR TITLE
Add bootstrap-owner CLI helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,19 @@ The test suite includes unit tests, integration tests, and "play tests" that run
 
 See also: CLI tool.
 
+#### Bootstrapping the First Admin
+
+Fresh databases contain zero users. The server still allows the first remote registration for backwards compatibility, but production deployments should explicitly seed the owner account before exposing the port. Use the CLI helper:
+
+```bash
+cd server
+uv run python -m server.cli bootstrap-owner --username admin
+```
+
+The command prompts for a password (or accept `--password-file/--password-stdin`) and creates an approved `SERVER_OWNER` user. Passing `--force` lets you update an existing account’s password/trust level if you’re repairing a database.
+
+When the server starts and finds zero users, it now prints a warning reminding you to run the bootstrap command. Automated test environments can silence the message by setting `PLAYPALACE_SUPPRESS_BOOTSTRAP_WARNING=1`, but this is not recommended for real deployments.
+
 ## Available Games
 
 Note: many games are still works in progress.

--- a/server/cli.py
+++ b/server/cli.py
@@ -30,6 +30,7 @@ import argparse
 import json
 import sys
 from dataclasses import dataclass, field
+from getpass import getpass
 from pathlib import Path
 from typing import Any
 
@@ -45,7 +46,9 @@ Localization.init(_MODULE_DIR / "locales")
 
 from server.games.registry import GameRegistry, get_game_class  # noqa: E402
 from server.games.base import Game, BOT_NAMES  # noqa: E402
-from server.users.base import User, generate_uuid  # noqa: E402
+from server.persistence.database import Database  # noqa: E402
+from server.auth.auth import AuthManager  # noqa: E402
+from server.users.base import User, generate_uuid, TrustLevel  # noqa: E402
 from server.users.bot import Bot  # noqa: E402
 
 
@@ -476,6 +479,112 @@ def cmd_simulate(args):
                     print(f"  {line}")
 
 
+def _prompt_for_password() -> str:
+    """Interactively prompt for a password twice."""
+    while True:
+        pw = getpass("New owner password: ")
+        confirm = getpass("Confirm password: ")
+        if pw != confirm:
+            print("Passwords do not match. Try again.")
+            continue
+        if not pw:
+            print("Password cannot be empty.")
+            continue
+        return pw
+
+
+def _resolve_bootstrap_password(args: argparse.Namespace) -> str:
+    """Resolve password from CLI arguments."""
+    if args.password is not None:
+        return args.password
+    if args.password_file:
+        path = Path(args.password_file)
+        return path.read_text(encoding="utf-8").rstrip("\r\n")
+    if args.password_stdin:
+        data = sys.stdin.read()
+        return data.rstrip("\r\n")
+    return _prompt_for_password()
+
+
+def bootstrap_owner(
+    *,
+    db_path: str,
+    username: str,
+    password: str,
+    locale: str = "en",
+    force: bool = False,
+    quiet: bool = False,
+) -> str:
+    """
+    Create or update the initial server owner account.
+
+    Returns a short status string describing the action performed.
+    Raises RuntimeError if the operation is not permitted.
+    """
+    if not password:
+        raise RuntimeError("Password cannot be empty.")
+
+    database = Database(db_path)
+    database.connect()
+
+    try:
+        auth = AuthManager(database)
+        user_count = database.get_user_count()
+        password_hash = auth.hash_password(password)
+
+        if user_count > 0 and not force:
+            raise RuntimeError(
+                "Database already contains users. Use --force if you intend to replace or update an existing account."
+            )
+
+        if database.user_exists(username):
+            if not force:
+                raise RuntimeError(
+                    f"User '{username}' already exists. Use --force to elevate/update the account."
+                )
+            database.update_user_password(username, password_hash)
+            database.update_user_trust_level(username, TrustLevel.SERVER_OWNER)
+            database.approve_user(username)
+            action = "Updated"
+        else:
+            database.create_user(
+                username=username,
+                password_hash=password_hash,
+                locale=locale,
+                trust_level=TrustLevel.SERVER_OWNER,
+                approved=True,
+            )
+            action = "Created"
+
+        if not quiet:
+            print(f"{action} server owner '{username}' in {db_path}.")
+        return action
+    finally:
+        database.close()
+
+
+def cmd_bootstrap_owner(args: argparse.Namespace) -> None:
+    """Handle the bootstrap-owner CLI command."""
+    try:
+        password = _resolve_bootstrap_password(args)
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"Error reading password: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        bootstrap_owner(
+            db_path=args.db_path,
+            username=args.username,
+            password=password,
+            locale=args.locale,
+            force=args.force,
+            quiet=args.quiet,
+        )
+    except RuntimeError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="PlayPalace CLI for AI agents",
@@ -528,6 +637,49 @@ def main():
         help="Save and restore game state after each tick to test serialization",
     )
 
+    # bootstrap-owner command
+    bootstrap_parser = subparsers.add_parser(
+        "bootstrap-owner", help="Create or repair the initial server owner account"
+    )
+    bootstrap_parser.add_argument(
+        "--username",
+        required=True,
+        help="Username for the owner account",
+    )
+    bootstrap_parser.add_argument(
+        "--password",
+        help="Password for the owner account (use with caution)",
+    )
+    bootstrap_parser.add_argument(
+        "--password-file",
+        help="Read password from a file (first line is used)",
+    )
+    bootstrap_parser.add_argument(
+        "--password-stdin",
+        action="store_true",
+        help="Read password from stdin (useful for automation)",
+    )
+    bootstrap_parser.add_argument(
+        "--db-path",
+        default="server/playpalace.db",
+        help="Path to the PlayPalace database (default: server/playpalace.db)",
+    )
+    bootstrap_parser.add_argument(
+        "--locale",
+        default="en",
+        help="Locale to assign to the owner account (default: en)",
+    )
+    bootstrap_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Allow replacing or updating an existing account even if other users exist",
+    )
+    bootstrap_parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress success output (useful for CI)",
+    )
+
     args = parser.parse_args()
 
     if args.command == "list-games":
@@ -536,6 +688,8 @@ def main():
         cmd_show_options(args)
     elif args.command == "simulate":
         cmd_simulate(args)
+    elif args.command == "bootstrap-owner":
+        cmd_bootstrap_owner(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/server/tests/test_cli_bootstrap.py
+++ b/server/tests/test_cli_bootstrap.py
@@ -1,0 +1,115 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from server.cli import bootstrap_owner
+from server.persistence.database import Database
+from server.users.base import TrustLevel
+from server.auth.auth import AuthManager
+from server.core.server import Server, BOOTSTRAP_WARNING_ENV
+
+LOCALES_DIR = Path(__file__).resolve().parents[1] / "locales"
+
+
+def test_bootstrap_owner_creates_new_owner(tmp_path):
+    db_path = tmp_path / "playpalace.db"
+
+    bootstrap_owner(
+        db_path=str(db_path),
+        username="admin",
+        password="secret-pass",
+        locale="en",
+        force=False,
+        quiet=True,
+    )
+
+    database = Database(db_path)
+    database.connect()
+    try:
+        user = database.get_user("admin")
+        assert user is not None
+        assert user.trust_level == TrustLevel.SERVER_OWNER
+        assert user.approved
+
+        auth = AuthManager(database)
+        assert auth.verify_password("secret-pass", user.password_hash)
+    finally:
+        database.close()
+
+
+def test_bootstrap_owner_requires_force_when_users_exist(tmp_path):
+    db_path = tmp_path / "existing.db"
+    database = Database(db_path)
+    database.connect()
+    try:
+        auth = AuthManager(database)
+        database.create_user(
+            username="existing",
+            password_hash=auth.hash_password("pw"),
+            trust_level=TrustLevel.USER,
+            approved=False,
+        )
+    finally:
+        database.close()
+
+    with pytest.raises(RuntimeError):
+        bootstrap_owner(
+            db_path=str(db_path),
+            username="admin",
+            password="secret",
+            force=False,
+            quiet=True,
+        )
+
+
+def test_bootstrap_owner_force_updates_existing_user(tmp_path):
+    db_path = tmp_path / "override.db"
+    database = Database(db_path)
+    database.connect()
+    try:
+        auth = AuthManager(database)
+        database.create_user(
+            username="admin",
+            password_hash=auth.hash_password("old"),
+            trust_level=TrustLevel.USER,
+            approved=False,
+        )
+    finally:
+        database.close()
+
+    bootstrap_owner(
+        db_path=str(db_path),
+        username="admin",
+        password="new-secret",
+        force=True,
+        quiet=True,
+    )
+
+    database = Database(db_path)
+    database.connect()
+    try:
+        user = database.get_user("admin")
+        assert user.trust_level == TrustLevel.SERVER_OWNER
+        assert user.approved
+        auth = AuthManager(database)
+        assert auth.verify_password("new-secret", user.password_hash)
+    finally:
+        database.close()
+
+
+def test_warn_if_no_users_prints_message(capsys, tmp_path):
+    server = Server(db_path=str(tmp_path / "db.sqlite"), locales_dir=LOCALES_DIR)
+    server._db = SimpleNamespace(get_user_count=lambda: 0)
+    server._warn_if_no_users()
+    out = capsys.readouterr().out
+    assert "bootstrap-owner" in out
+
+
+def test_warn_if_no_users_respects_env(monkeypatch, capsys, tmp_path):
+    server = Server(db_path=str(tmp_path / "db.sqlite"), locales_dir=LOCALES_DIR)
+    server._db = SimpleNamespace(get_user_count=lambda: 0)
+    monkeypatch.setenv(BOOTSTRAP_WARNING_ENV, "1")
+    server._warn_if_no_users()
+    out = capsys.readouterr().out
+    assert out == ""


### PR DESCRIPTION
## Summary
- add a `server.cli bootstrap-owner` command that prompts for credentials (or accepts file/stdin) and seeds or repairs the `SERVER_OWNER` account
- print a startup warning whenever the database has zero users so operators know to bootstrap before exposing the port
- document the workflow in README and add regression coverage for the new CLI entry point

## Testing
- cd server && uv run python -m cli bootstrap-owner --help

Fixes #65.
