### PR TITLE
Spectator summary visibility fixes

### DIFF
--- a/server/game_utils/action_visibility_mixin.py
+++ b/server/game_utils/action_visibility_mixin.py
@@ -152,7 +152,9 @@ class ActionVisibilityMixin:
         return None
 
     def _is_show_actions_hidden(self, player: "Player") -> Visibility:
-        """Show actions is always hidden (keybind only)."""
+        """Show actions is hidden for players but visible to spectators."""
+        if player.is_spectator:
+            return Visibility.VISIBLE
         return Visibility.HIDDEN
 
     def _is_save_table_enabled(self, player: "Player") -> str | None:

--- a/server/games/crazyeights/game.py
+++ b/server/games/crazyeights/game.py
@@ -1121,7 +1121,7 @@ class CrazyEightsGame(Game):
         points_from: list[tuple[CrazyEightsPlayer, int]] = []
         total = 0
         for p in self.players:
-            if not isinstance(p, CrazyEightsPlayer):
+            if not isinstance(p, CrazyEightsPlayer) or p.is_spectator:
                 continue
             if p.id == winner.id:
                 continue
@@ -1283,7 +1283,11 @@ class CrazyEightsGame(Game):
 
         for p in self.players:
             user = self.get_user(p)
-            if not user or not isinstance(p, CrazyEightsPlayer):
+            if (
+                not user
+                or not isinstance(p, CrazyEightsPlayer)
+                or p.is_spectator
+            ):
                 continue
             if p.id == winner.id:
                 user.play_sound(win_sound)

--- a/server/games/leftrightcenter/game.py
+++ b/server/games/leftrightcenter/game.py
@@ -421,7 +421,7 @@ class LeftRightCenterGame(Game):
             custom_data={
                 "winner_name": winner.name if winner else None,
                 "center_pot": self.center_pot,
-                "final_chips": {p.name: p.chips for p in self.players},
+                "final_chips": {p.name: p.chips for p in active_players},
             },
         )
 

--- a/server/games/lightturret/game.py
+++ b/server/games/lightturret/game.py
@@ -448,22 +448,26 @@ class LightTurretGame(Game):
         max_light = 0
         winners = []
         for p in self.players:
-            if isinstance(p, LightTurretPlayer):
-                # Announce each player's result
-                if p.alive:
-                    self.broadcast_l(
-                        "lightturret-final-alive", player=p.name, light=p.light
-                    )
-                else:
-                    self.broadcast_l(
-                        "lightturret-final-eliminated", player=p.name, light=p.light
-                    )
+            if (
+                not isinstance(p, LightTurretPlayer)
+                or p.is_spectator
+            ):
+                continue
+            # Announce each player's result
+            if p.alive:
+                self.broadcast_l(
+                    "lightturret-final-alive", player=p.name, light=p.light
+                )
+            else:
+                self.broadcast_l(
+                    "lightturret-final-eliminated", player=p.name, light=p.light
+                )
 
-                if p.light > max_light:
-                    max_light = p.light
-                    winners = [p]
-                elif p.light == max_light:
-                    winners.append(p)
+            if p.light > max_light:
+                max_light = p.light
+                winners = [p]
+            elif p.light == max_light:
+                winners.append(p)
 
         # Announce winner or tie
         if len(winners) > 1:
@@ -492,7 +496,11 @@ class LightTurretGame(Game):
     def build_game_result(self) -> GameResult:
         """Build the game result with LightTurret-specific data."""
         sorted_players = sorted(
-            [p for p in self.players if isinstance(p, LightTurretPlayer)],
+            [
+                p
+                for p in self.players
+                if isinstance(p, LightTurretPlayer) and not p.is_spectator
+            ],
             key=lambda p: p.light,
             reverse=True,
         )

--- a/server/games/threes/game.py
+++ b/server/games/threes/game.py
@@ -401,10 +401,17 @@ class ThreesGame(Game, DiceGameMixin):
 
     def _end_game(self) -> None:
         """End the game and announce winner."""
-        # Find winner(s) (lowest score)
-        players_with_scores = [
-            (p, p.total_score) for p in self.players if isinstance(p, ThreesPlayer)
+        # Only consider active (non-spectator) players when picking winners
+        active_players = [
+            p
+            for p in self.players
+            if isinstance(p, ThreesPlayer) and not p.is_spectator
         ]
+        if not active_players:
+            return
+
+        # Find winner(s) (lowest score)
+        players_with_scores = [(p, p.total_score) for p in active_players]
         players_with_scores.sort(key=lambda x: x[1])
 
         lowest_score = players_with_scores[0][1]
@@ -425,7 +432,11 @@ class ThreesGame(Game, DiceGameMixin):
         """Build the game result with Threes-specific data."""
         # Sorted by score ascending (lowest wins)
         sorted_players = sorted(
-            [p for p in self.players if isinstance(p, ThreesPlayer)],
+            [
+                p
+                for p in self.players
+                if isinstance(p, ThreesPlayer) and not p.is_spectator
+            ],
             key=lambda p: p.total_score,
         )
 


### PR DESCRIPTION
## Summary
- align action visibility mixin so spectators consistently see allowed events
- patch game-specific summary builders (Crazy Eights, LRC, Light Turret, Threes)
- ensure spectator summaries no longer miss turns or error on hidden actions

## Testing
- pytest server/tests/test_virtual_bots.py::TestSpectatorSummaries

Closes #75