### PR TITLE
Add GameRegistry.get_game_class alias

### DIFF
--- a/server/games/registry.py
+++ b/server/games/registry.py
@@ -23,6 +23,11 @@ class GameRegistry:
         return cls._games.get(game_type)
 
     @classmethod
+    def get_game_class(cls, game_type: str) -> Type["Game"] | None:
+        """Backward compatible alias for getting a game class by type."""
+        return cls.get(game_type)
+
+    @classmethod
     def get_all(cls) -> list[Type["Game"]]:
         """Get all registered game classes."""
         return list(cls._games.values())


### PR DESCRIPTION
## Summary
- add compatibility alias for GameRegistry.get_game_class to match historical API
- keep existing registry lookup implementation so downstream tooling works without patches

## Testing
- pytest server/tests/test_registry.py::TestGameRegistry::test_get_game_class_alias

Closes #76