### PR TITLE
Add Linux launchers for client and server

### DIFF
--- a/linux-client
+++ b/linux-client
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLIENT_DIR="$ROOT/client"
+
+need_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Error: '$cmd' is required but not found in PATH." >&2
+    exit 1
+  fi
+}
+
+check_python() {
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "Error: python3 is required (>= 3.11)." >&2
+    exit 1
+  fi
+  python3 - <<'PY'
+import sys
+if sys.version_info < (3, 11):
+    raise SystemExit("Error: Python 3.11+ is required.")
+PY
+}
+
+check_client_deps() {
+  if ! (cd "$CLIENT_DIR" && uv run python - <<'PY'
+import wx
+import accessible_output2
+import websockets
+import sound_lib
+PY
+  ); then
+    echo "Error: client dependencies are missing." >&2
+    echo "Run: cd client && uv sync" >&2
+    exit 1
+  fi
+}
+
+need_cmd uv
+check_python
+check_client_deps
+
+(
+  cd "$CLIENT_DIR"
+  export G_MESSAGES_DEBUG=""
+  export GTK_DISABLE_GAIL_WARNING=1
+  uv run python client.py
+)

--- a/linux-server
+++ b/linux-server
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SERVER_DIR="$ROOT/server"
+
+need_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Error: '$cmd' is required but not found in PATH." >&2
+    exit 1
+  fi
+}
+
+check_python() {
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "Error: python3 is required (>= 3.11)." >&2
+    exit 1
+  fi
+  python3 - <<'PY'
+import sys
+if sys.version_info < (3, 11):
+    raise SystemExit("Error: Python 3.11+ is required.")
+PY
+}
+
+check_server_deps() {
+  if ! (cd "$SERVER_DIR" && uv run python - <<'PY'
+import websockets
+import mashumaro
+import fluent_compiler
+import babel
+import openskill
+import argon2
+PY
+  ); then
+    echo "Error: server dependencies are missing." >&2
+    echo "Run: cd server && uv sync" >&2
+    exit 1
+  fi
+}
+
+need_cmd uv
+check_python
+check_server_deps
+
+(cd "$SERVER_DIR" && uv run python main.py)


### PR DESCRIPTION
Adds linux-client and linux-server scripts to check deps and launch the client/server on common Linux distros without Nix.

- Verify Python 3.11+ and uv
- Check required imports for client/server
- Run client/server with no args
