### PR TITLE
Add fatal startup checks and tests

### DIFF
--- a/server/core/tick.py
+++ b/server/core/tick.py
@@ -1,6 +1,7 @@
 """Tick scheduler for game updates."""
 
 import asyncio
+import sys
 from pathlib import Path
 from typing import Callable
 
@@ -31,8 +32,15 @@ def load_server_config(path: str | Path | None = None) -> dict:
     except ImportError:
         import tomli as tomllib
 
-    with open(path, "rb") as f:
-        data = tomllib.load(f)
+    try:
+        with open(path, "rb") as f:
+            data = tomllib.load(f)
+    except tomllib.TOMLDecodeError as exc:
+        print(f"ERROR: Failed to parse configuration file '{path}': {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+    except OSError as exc:
+        print(f"ERROR: Failed to read configuration file '{path}': {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
 
     return data.get("server", {})
 

--- a/server/network/websocket_server.py
+++ b/server/network/websocket_server.py
@@ -2,6 +2,7 @@
 
 import json
 import ssl
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Coroutine
@@ -66,7 +67,14 @@ class WebSocketServer:
         # Configure SSL if certificates provided
         if ssl_cert and ssl_key:
             self._ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-            self._ssl_context.load_cert_chain(str(ssl_cert), str(ssl_key))
+            try:
+                self._ssl_context.load_cert_chain(str(ssl_cert), str(ssl_key))
+            except Exception as exc:  # pylint: disable=broad-except
+                print(
+                    f"ERROR: Failed to load TLS certificate or key ({ssl_cert}, {ssl_key}): {exc}",
+                    file=sys.stderr,
+                )
+                raise SystemExit(1) from exc
 
     @property
     def clients(self) -> dict[str, ClientConnection]:
@@ -77,13 +85,20 @@ class WebSocketServer:
         """Start the WebSocket server."""
         self._running = True
         # Manually enter the context manager to control lifecycle
-        self._server = await serve(
-            self._handle_client,
-            self.host,
-            self.port,
-            ssl=self._ssl_context,
-            max_size=self._max_message_size,
-        ).__aenter__()
+        try:
+            self._server = await serve(
+                self._handle_client,
+                self.host,
+                self.port,
+                ssl=self._ssl_context,
+                max_size=self._max_message_size,
+            ).__aenter__()
+        except OSError as exc:
+            print(
+                f"ERROR: Failed to bind WebSocket server on {self.host}:{self.port}: {exc}",
+                file=sys.stderr,
+            )
+            raise SystemExit(1) from exc
         
         protocol = "wss" if self._ssl_context else "ws"
         print(f"WebSocket server started on {protocol}://{self.host}:{self.port}")

--- a/server/persistence/database.py
+++ b/server/persistence/database.py
@@ -1,6 +1,7 @@
 """SQLite database for persistence."""
 
 import sqlite3
+import sys
 import json
 from pathlib import Path
 from dataclasses import dataclass
@@ -49,7 +50,14 @@ class Database:
 
     def connect(self) -> None:
         """Connect to the database and create tables if needed."""
-        self._conn = sqlite3.connect(str(self.db_path))
+        try:
+            self._conn = sqlite3.connect(str(self.db_path))
+        except sqlite3.Error as exc:
+            print(
+                f"ERROR: Failed to open database at '{self.db_path}': {exc}",
+                file=sys.stderr,
+            )
+            raise SystemExit(1) from exc
         self._conn.row_factory = sqlite3.Row
         self._create_tables()
 

--- a/server/tests/test_startup_errors.py
+++ b/server/tests/test_startup_errors.py
@@ -1,0 +1,118 @@
+from pathlib import Path
+
+import pytest
+
+from server.core.server import Server
+from server.network import websocket_server as websocket_module
+
+
+def _write_config(tmp_path: Path, allow_insecure: bool, tick_interval: int | None = None) -> Path:
+    lines = ["[network]", f"allow_insecure_ws = {'true' if allow_insecure else 'false'}", ""]
+    if tick_interval is not None:
+        lines.extend(["[server]", f"tick_interval_ms = {tick_interval}", ""])
+    config_path = tmp_path / "config.toml"
+    config_path.write_text("\n".join(lines), encoding="utf-8")
+    return config_path
+
+
+def test_localization_missing_directory(tmp_path, capsys):
+    missing_locales = tmp_path / "missing_locales"
+    with pytest.raises(SystemExit):
+        Server(locales_dir=missing_locales)
+    captured = capsys.readouterr()
+    assert "Localization directory" in captured.err
+
+
+@pytest.mark.asyncio
+async def test_tls_certificate_load_failure(tmp_path, capsys):
+    server = Server(
+        db_path=str(tmp_path / "db.sqlite"),
+        ssl_cert=tmp_path / "missing_cert.pem",
+        ssl_key=tmp_path / "missing_key.pem",
+    )
+    with pytest.raises(SystemExit):
+        await server.start()
+    captured = capsys.readouterr()
+    assert "Failed to load TLS certificate or key" in captured.err
+
+
+@pytest.mark.asyncio
+async def test_websocket_bind_failure(tmp_path, monkeypatch, capsys):
+    config_path = _write_config(tmp_path, allow_insecure=True)
+
+    class FailingServe:
+        async def __aenter__(self):
+            raise OSError("address already in use")
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    def fake_serve(*args, **kwargs):
+        return FailingServe()
+
+    monkeypatch.setattr(websocket_module, "serve", fake_serve)
+
+    server = Server(
+        db_path=str(tmp_path / "db.sqlite"),
+        config_path=config_path,
+    )
+    with pytest.raises(SystemExit):
+        await server.start()
+    captured = capsys.readouterr()
+    assert "Failed to bind WebSocket server" in captured.err
+
+
+@pytest.mark.asyncio
+async def test_database_connection_failure(tmp_path, capsys):
+    config_path = _write_config(tmp_path, allow_insecure=True)
+    db_path = tmp_path / "dbdir"
+    db_path.mkdir()
+    server = Server(
+        db_path=str(db_path),
+        config_path=config_path,
+    )
+    with pytest.raises(SystemExit):
+        await server.start()
+    captured = capsys.readouterr()
+    assert "Failed to open database" in captured.err
+
+
+@pytest.mark.asyncio
+async def test_tick_interval_invalid(tmp_path, capsys):
+    config_path = _write_config(tmp_path, allow_insecure=True, tick_interval=0)
+    server = Server(
+        db_path=str(tmp_path / "db.sqlite"),
+        config_path=config_path,
+    )
+    with pytest.raises(SystemExit):
+        await server.start()
+    captured = capsys.readouterr()
+    assert "tick_interval_ms must be at least 1" in captured.err
+
+
+@pytest.mark.asyncio
+async def test_tls_required_without_cert(tmp_path, capsys):
+    config_path = _write_config(tmp_path, allow_insecure=False)
+    server = Server(
+        db_path=str(tmp_path / "db.sqlite"),
+        config_path=config_path,
+    )
+    with pytest.raises(SystemExit):
+        await server.start()
+    captured = capsys.readouterr()
+    assert "TLS is required" in captured.err
+
+
+@pytest.mark.asyncio
+async def test_insecure_mode_with_cert_conflict(tmp_path, capsys):
+    config_path = _write_config(tmp_path, allow_insecure=True)
+    server = Server(
+        db_path=str(tmp_path / "db.sqlite"),
+        config_path=config_path,
+        ssl_cert="cert.pem",
+        ssl_key="key.pem",
+    )
+    with pytest.raises(SystemExit):
+        await server.start()
+    captured = capsys.readouterr()
+    assert "allow_insecure_ws=true cannot be combined" in captured.err


### PR DESCRIPTION
## Summary
- add explicit startup failures for missing localization assets, bad configs, TLS misconfiguration, socket binds, and database access
- ensure tick interval parsing and virtual bot setup exit loudly on invalid settings
- add regression coverage for each fatal startup scenario

## Testing
- ============================= test session starts ==============================
platform linux -- Python 3.13.2, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/ccn/aider/PlayPalace11/server
configfile: pyproject.toml
plugins: asyncio-1.3.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 7 items

tests/test_startup_errors.py .......                                     [100%]

========================= 7 passed in 72.48s (0:01:12) =========================

Fixes XGDevGroup/PlayPalace11#83
