### PR TITLE
Unify dice helpers and bot scaffolding

### DIFF
--- a/server/game_utils/action_guard_mixin.py
+++ b/server/game_utils/action_guard_mixin.py
@@ -1,0 +1,53 @@
+"""Shared helpers for common action guard logic."""
+
+from __future__ import annotations
+
+from .actions import Visibility
+
+
+class ActionGuardMixin:
+    """Provides reusable guard logic for turn actions."""
+
+    def guard_game_active(self) -> str | None:
+        """Return standard error code if game is not currently playing."""
+        if getattr(self, "status", None) != "playing":
+            return "action-not-playing"
+        return None
+
+    def guard_turn_action_enabled(
+        self,
+        player,
+        *,
+        allow_spectators: bool = False,
+        require_current_player: bool = True,
+    ) -> str | None:
+        """Common rules for checking if a player can perform a turn action."""
+        error = self.guard_game_active()
+        if error:
+            return error
+        if not allow_spectators and getattr(player, "is_spectator", False):
+            return "action-spectator"
+        if require_current_player and getattr(self, "current_player", None) != player:
+            return "action-not-your-turn"
+        return None
+
+    def turn_action_visibility(
+        self,
+        player,
+        *,
+        allow_spectators: bool = False,
+        require_current_player: bool = True,
+        extra_condition: bool = True,
+    ) -> Visibility:
+        """Return Visibility for a turn action with optional extra conditions."""
+        error = self.guard_turn_action_enabled(
+            player,
+            allow_spectators=allow_spectators,
+            require_current_player=require_current_player,
+        )
+        if error is None and extra_condition:
+            return Visibility.VISIBLE
+        return Visibility.HIDDEN
+
+
+__all__ = ["ActionGuardMixin"]

--- a/server/game_utils/dice.py
+++ b/server/game_utils/dice.py
@@ -1,7 +1,9 @@
 """Dice utilities for dice-based games."""
 
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 import random
+from typing import Sequence
 
 from mashumaro.mixins.json import DataClassJSONMixin
 
@@ -246,3 +248,107 @@ def roll_dice(num_dice: int = 1, sides: int = 6) -> list[int]:
 def roll_die(sides: int = 6) -> int:
     """Roll a single die and return its value."""
     return random.randint(1, sides)
+
+
+def count_dice(dice: Iterable[int], *, sides: int = 6) -> dict[int, int]:
+    """Count occurrences of each die value."""
+    counts = {i: 0 for i in range(1, sides + 1)} if sides else {}
+    for value in dice:
+        if value in counts:
+            counts[value] += 1
+        else:
+            counts[value] = counts.get(value, 0) + 1
+    return counts
+
+
+def _coerce_counts(
+    dice_or_counts: Iterable[int] | Mapping[int, int], *, sides: int = 6
+) -> dict[int, int]:
+    if isinstance(dice_or_counts, Mapping):
+        base = {i: dice_or_counts.get(i, 0) for i in range(1, sides + 1)} if sides else {}
+        for key, value in dice_or_counts.items():
+            if key not in base:
+                base[key] = value
+        return base
+    if isinstance(dice_or_counts, Sequence):
+        return count_dice(dice_or_counts, sides=sides)
+    return count_dice(list(dice_or_counts), sides=sides)
+
+
+def has_n_of_a_kind(
+    dice_or_counts: Iterable[int] | Mapping[int, int],
+    count: int,
+    value: int | None = None,
+    *,
+    sides: int = 6,
+) -> bool:
+    """Return True if there are ``count`` or more of ``value`` (or any value)."""
+    counts = _coerce_counts(dice_or_counts, sides=sides)
+    if value is not None:
+        return counts.get(value, 0) >= count
+    return any(v >= count for v in counts.values())
+
+
+def count_exact_matches(
+    dice_or_counts: Iterable[int] | Mapping[int, int],
+    exact: int,
+    *,
+    sides: int = 6,
+) -> int:
+    """Count how many distinct values appear exactly ``exact`` times."""
+    counts = _coerce_counts(dice_or_counts, sides=sides)
+    return sum(1 for v in counts.values() if v == exact)
+
+
+def has_consecutive_run(
+    dice_or_counts: Iterable[int] | Mapping[int, int],
+    length: int,
+    *,
+    min_value: int = 1,
+    max_value: int | None = None,
+    require_unique: bool = False,
+    sides: int = 6,
+) -> bool:
+    """Return True if there is a run of ``length`` consecutive values."""
+    counts = _coerce_counts(dice_or_counts, sides=sides)
+    if not max_value:
+        max_value = max(counts.keys(), default=0)
+    run = 0
+    for value in range(min_value, max_value + 1):
+        count = counts.get(value, 0)
+        if count > 0 and (not require_unique or count == 1):
+            run += 1
+            if run >= length:
+                return True
+        else:
+            run = 0
+    return False
+
+
+def has_full_house(
+    dice_or_counts: Iterable[int] | Mapping[int, int],
+    *,
+    allow_five_kind: bool = False,
+    sides: int = 6,
+) -> bool:
+    """Return True if counts contain a 3-of-a-kind and a pair (optionally 5-kind)."""
+    counts = _coerce_counts(dice_or_counts, sides=sides)
+    has_three = any(v == 3 for v in counts.values())
+    has_two = any(v == 2 for v in counts.values())
+    if has_three and has_two:
+        return True
+    if allow_five_kind and any(v == 5 for v in counts.values()):
+        return True
+    return False
+
+
+__all__ = [
+    "DiceSet",
+    "roll_dice",
+    "roll_die",
+    "count_dice",
+    "has_n_of_a_kind",
+    "count_exact_matches",
+    "has_consecutive_run",
+    "has_full_house",
+]

--- a/server/game_utils/push_your_luck_mixin.py
+++ b/server/game_utils/push_your_luck_mixin.py
@@ -1,0 +1,50 @@
+"""Shared bot scaffolding for push-your-luck dice games."""
+
+from __future__ import annotations
+
+import random
+from typing import ClassVar
+
+from .bot_helper import BotHelper
+
+
+class PushYourLuckBotMixin:
+    """Provides reusable logic for target-based push-your-luck bots."""
+
+    push_target_range: ClassVar[tuple[int, int]] = (10, 25)
+
+    def on_tick(self) -> None:
+        """Ensure bot targets persist across reloads and drive BotHelper."""
+        super().on_tick()
+        if not getattr(self, "game_active", False):
+            return
+
+        player = getattr(self, "current_player", None)
+        if player and getattr(player, "is_bot", False) and BotHelper.get_target(player) is None:
+            self._set_push_bot_target(player)
+
+        BotHelper.on_tick(self)
+
+    def prepare_push_bot_turn(self, player) -> None:
+        """Call at start of a bot's turn to (re)initialize its target."""
+        if player and getattr(player, "is_bot", False):
+            self._set_push_bot_target(player)
+
+    # ------------------------------------------------------------------
+    # Hooks for subclasses
+    # ------------------------------------------------------------------
+    def _set_push_bot_target(self, player) -> None:
+        target = self._calculate_push_bot_target(player)
+        BotHelper.set_target(player, max(0, target))
+
+    def _calculate_push_bot_target(self, player) -> int:
+        low, high = self.push_target_range
+        base = random.randint(low, high)
+        return self._adjust_push_bot_target(player, base)
+
+    def _adjust_push_bot_target(self, player, target: int) -> int:
+        """Override to tweak the per-turn target using game-specific heuristics."""
+        return target
+
+
+__all__ = ["PushYourLuckBotMixin"]

--- a/server/game_utils/teams.py
+++ b/server/game_utils/teams.py
@@ -5,6 +5,8 @@ Provides Team dataclass and TeamManager for handling team assignments,
 scoring, and elimination (for inverse game modes).
 """
 
+from collections import OrderedDict
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -432,3 +434,30 @@ class TeamManager(DataClassJSONMixin):
             name = self.get_team_name(team, locale)
             lines.append(f"{name}: {team.total_score} points")
         return lines
+
+
+class TeamResultBuilder:
+    """Helpers for summarizing and formatting team-based results."""
+
+    @staticmethod
+    def summarize(team_manager: TeamManager):
+        """Return (sorted_teams, winner, ordered final_scores dict)."""
+        sorted_teams = team_manager.get_sorted_teams(by_score=True, descending=True)
+        winner = sorted_teams[0] if sorted_teams else None
+        final_scores: OrderedDict[str, int] = OrderedDict()
+        for team in sorted_teams:
+            name = team_manager.get_team_name(team)
+            final_scores[name] = team.total_score
+        return sorted_teams, winner, final_scores
+
+    @staticmethod
+    def format_final_scores(locale: str, final_scores: Mapping[str, int]) -> list[str]:
+        """Format localized final score lines."""
+        lines = [Localization.get(locale, "game-final-scores")]
+        for index, (name, score) in enumerate(final_scores.items(), 1):
+            points = Localization.get(locale, "game-points", count=score)
+            lines.append(f"{index}. {name}: {points}")
+        return lines
+
+
+__all__ = ["Team", "TeamManager", "TeamResultBuilder"]

--- a/server/games/farkle/game.py
+++ b/server/games/farkle/game.py
@@ -11,8 +11,15 @@ import random
 
 from ..base import Game, Player, GameOptions
 from ..registry import register_game
+from ...game_utils.action_guard_mixin import ActionGuardMixin
 from ...game_utils.actions import Action, ActionSet, Visibility
 from ...game_utils.bot_helper import BotHelper
+from ...game_utils.dice import (
+    count_dice,
+    count_exact_matches,
+    has_consecutive_run,
+    has_n_of_a_kind,
+)
 from ...game_utils.game_result import GameResult, PlayerResult
 from ...game_utils.options import IntOption, option_field
 from ...messages.localization import Localization
@@ -77,16 +84,6 @@ COMBO_SOUNDS = {
     COMBO_DOUBLE_TRIPLETS: "game_farkle/doubletriplets.ogg",
     COMBO_FULL_HOUSE: "game_farkle/fullhouse.ogg",
 }
-
-
-def count_dice(dice: list[int]) -> dict[int, int]:
-    """Count occurrences of each die value (1-6)."""
-    counts = {i: 0 for i in range(1, 7)}
-    for die in dice:
-        counts[die] += 1
-    return counts
-
-
 def has_combination(dice: list[int], combo_type: str, number: int = 0) -> bool:
     """Check if dice contain a specific combination."""
     counts = count_dice(dice)
@@ -96,35 +93,25 @@ def has_combination(dice: list[int], combo_type: str, number: int = 0) -> bool:
     elif combo_type == COMBO_SINGLE_5:
         return counts[5] >= 1
     elif combo_type == COMBO_THREE_OF_KIND:
-        return counts[number] >= 3
+        return has_n_of_a_kind(counts, 3, value=number)
     elif combo_type == COMBO_FOUR_OF_KIND:
-        return counts[number] >= 4
+        return has_n_of_a_kind(counts, 4, value=number)
     elif combo_type == COMBO_FIVE_OF_KIND:
-        return counts[number] >= 5
+        return has_n_of_a_kind(counts, 5, value=number)
     elif combo_type == COMBO_SIX_OF_KIND:
-        return counts[number] == 6
+        return has_n_of_a_kind(counts, 6, value=number)
     elif combo_type == COMBO_LARGE_STRAIGHT:
-        if len(dice) != 6:
-            return False
-        return all(counts[i] == 1 for i in range(1, 7))
+        return has_consecutive_run(counts, length=6, min_value=1, max_value=6, require_unique=True)
     elif combo_type == COMBO_SMALL_STRAIGHT:
-        if len(dice) < 5:
-            return False
-        # Check for 1-2-3-4-5
-        has_1_5 = all(counts[i] >= 1 for i in range(1, 6))
-        # Check for 2-3-4-5-6
-        has_2_6 = all(counts[i] >= 1 for i in range(2, 7))
-        return has_1_5 or has_2_6
+        return has_consecutive_run(counts, length=5, min_value=1, max_value=6)
     elif combo_type == COMBO_THREE_PAIRS:
         if len(dice) != 6:
             return False
-        pairs = sum(1 for i in range(1, 7) if counts[i] == 2)
-        return pairs == 3
+        return count_exact_matches(counts, 2) == 3
     elif combo_type == COMBO_DOUBLE_TRIPLETS:
         if len(dice) != 6:
             return False
-        triplets = sum(1 for i in range(1, 7) if counts[i] == 3)
-        return triplets == 2
+        return count_exact_matches(counts, 3) == 2
     elif combo_type == COMBO_FULL_HOUSE:
         if len(dice) != 6:
             return False
@@ -170,35 +157,30 @@ def has_scoring_dice(dice: list[int]) -> bool:
     counts = count_dice(dice)
 
     # Single 1s or 5s
-    if counts[1] > 0 or counts[5] > 0:
+    if counts.get(1, 0) > 0 or counts.get(5, 0) > 0:
         return True
 
     # Three or more of a kind
-    if any(counts[i] >= 3 for i in range(1, 7)):
+    if has_n_of_a_kind(counts, 3):
         return True
 
     # Large straight (1-2-3-4-5-6)
-    if len(dice) == 6 and all(counts[i] == 1 for i in range(1, 7)):
+    if len(dice) == 6 and has_consecutive_run(
+        counts, length=6, min_value=1, max_value=6, require_unique=True
+    ):
         return True
 
     # Small straight
-    if len(dice) >= 5:
-        has_1_5 = all(counts[i] >= 1 for i in range(1, 6))
-        has_2_6 = all(counts[i] >= 1 for i in range(2, 7))
-        if has_1_5 or has_2_6:
-            return True
+    if len(dice) >= 5 and has_consecutive_run(counts, length=5, min_value=1, max_value=6):
+        return True
 
     # Three pairs
-    if len(dice) == 6:
-        pairs = sum(1 for i in range(1, 7) if counts[i] == 2)
-        if pairs == 3:
-            return True
+    if len(dice) == 6 and count_exact_matches(counts, 2) == 3:
+        return True
 
     # Double triplets
-    if len(dice) == 6:
-        triplets = sum(1 for i in range(1, 7) if counts[i] == 3)
-        if triplets == 2:
-            return True
+    if len(dice) == 6 and count_exact_matches(counts, 3) == 2:
+        return True
 
     return False
 
@@ -279,7 +261,7 @@ def get_available_combinations(dice: list[int]) -> list[tuple[str, int, int]]:
 
 @dataclass
 @register_game
-class FarkleGame(Game):
+class FarkleGame(ActionGuardMixin, Game):
     """
     Farkle dice game.
 
@@ -521,12 +503,9 @@ class FarkleGame(Game):
 
     def _is_roll_enabled(self, player: Player) -> str | None:
         """Check if roll action is enabled."""
-        if self.status != "playing":
-            return "action-not-playing"
-        if self.current_player != player:
-            return "action-not-your-turn"
-        if player.is_spectator:
-            return "action-spectator"
+        error = self.guard_turn_action_enabled(player)
+        if error:
+            return error
         farkle_player: FarklePlayer = player  # type: ignore
         can_roll = len(farkle_player.current_roll) == 0 or farkle_player.has_taken_combo
         if not can_roll:
@@ -535,15 +514,9 @@ class FarkleGame(Game):
 
     def _is_roll_hidden(self, player: Player) -> Visibility:
         """Check if roll action is hidden."""
-        if self.status != "playing":
-            return Visibility.HIDDEN
-        if self.current_player != player:
-            return Visibility.HIDDEN
         farkle_player: FarklePlayer = player  # type: ignore
         can_roll = len(farkle_player.current_roll) == 0 or farkle_player.has_taken_combo
-        if not can_roll:
-            return Visibility.HIDDEN
-        return Visibility.VISIBLE
+        return self.turn_action_visibility(player, extra_condition=can_roll)
 
     def _get_roll_label(self, player: Player, action_id: str) -> str:
         """Get dynamic label for roll action."""
@@ -555,12 +528,9 @@ class FarkleGame(Game):
 
     def _is_bank_enabled(self, player: Player) -> str | None:
         """Check if bank action is enabled."""
-        if self.status != "playing":
-            return "action-not-playing"
-        if self.current_player != player:
-            return "action-not-your-turn"
-        if player.is_spectator:
-            return "action-spectator"
+        error = self.guard_turn_action_enabled(player)
+        if error:
+            return error
         farkle_player: FarklePlayer = player  # type: ignore
         can_bank = farkle_player.turn_score > 0 and (
             len(farkle_player.current_roll) == 0
@@ -572,18 +542,12 @@ class FarkleGame(Game):
 
     def _is_bank_hidden(self, player: Player) -> Visibility:
         """Check if bank action is hidden."""
-        if self.status != "playing":
-            return Visibility.HIDDEN
-        if self.current_player != player:
-            return Visibility.HIDDEN
         farkle_player: FarklePlayer = player  # type: ignore
         can_bank = farkle_player.turn_score > 0 and (
             len(farkle_player.current_roll) == 0
             or not has_scoring_dice(farkle_player.current_roll)
         )
-        if not can_bank:
-            return Visibility.HIDDEN
-        return Visibility.VISIBLE
+        return self.turn_action_visibility(player, extra_condition=can_bank)
 
     def _get_bank_label(self, player: Player, action_id: str) -> str:
         """Get dynamic label for bank action."""
@@ -594,9 +558,7 @@ class FarkleGame(Game):
 
     def _is_check_turn_score_enabled(self, player: Player) -> str | None:
         """Check if check turn score action is enabled."""
-        if self.status != "playing":
-            return "action-not-playing"
-        return None
+        return self.guard_game_active()
 
     def _is_check_turn_score_hidden(self, player: Player) -> Visibility:
         """Check turn score is always hidden from menu (keybind only)."""
@@ -604,21 +566,11 @@ class FarkleGame(Game):
 
     def _is_scoring_action_enabled(self, player: Player) -> str | None:
         """Check if a scoring action is enabled (scoring actions are only created when available)."""
-        if self.status != "playing":
-            return "action-not-playing"
-        if self.current_player != player:
-            return "action-not-your-turn"
-        if player.is_spectator:
-            return "action-spectator"
-        return None
+        return self.guard_turn_action_enabled(player)
 
     def _is_scoring_action_hidden(self, player: Player) -> Visibility:
         """Check if a scoring action is hidden."""
-        if self.status != "playing":
-            return Visibility.HIDDEN
-        if self.current_player != player:
-            return Visibility.HIDDEN
-        return Visibility.VISIBLE
+        return self.turn_action_visibility(player)
 
     def _get_roll_dice_count(self, player: FarklePlayer) -> int:
         """Get the number of dice that will be rolled."""

--- a/server/games/leftrightcenter/game.py
+++ b/server/games/leftrightcenter/game.py
@@ -12,6 +12,7 @@ import random
 
 from ..base import Game, Player, GameOptions
 from ..registry import register_game
+from ...game_utils.action_guard_mixin import ActionGuardMixin
 from ...game_utils.actions import Action, ActionSet, Visibility
 from ...game_utils.bot_helper import BotHelper
 from ...game_utils.game_result import GameResult, PlayerResult
@@ -49,7 +50,7 @@ class LeftRightCenterOptions(GameOptions):
 
 @dataclass
 @register_game
-class LeftRightCenterGame(Game):
+class LeftRightCenterGame(ActionGuardMixin, Game):
     """Left Right Center dice game."""
 
     players: list[LeftRightCenterPlayer] = field(default_factory=list)
@@ -93,22 +94,11 @@ class LeftRightCenterGame(Game):
     # ==========================================================================
 
     def _is_roll_enabled(self, player: Player) -> str | None:
-        if self.status != "playing":
-            return "action-not-playing"
-        if player.is_spectator:
-            return "action-spectator"
-        if self.current_player != player:
-            return "action-not-your-turn"
-        return None
+        return self.guard_turn_action_enabled(player)
 
     def _is_roll_hidden(self, player: Player) -> Visibility:
-        if self.status != "playing" or player.is_spectator:
-            return Visibility.HIDDEN
-        if self.current_player != player:
-            return Visibility.HIDDEN
-        if isinstance(player, LeftRightCenterPlayer) and player.chips == 0:
-            return Visibility.HIDDEN
-        return Visibility.VISIBLE
+        has_chips = not isinstance(player, LeftRightCenterPlayer) or player.chips > 0
+        return self.turn_action_visibility(player, extra_condition=has_chips)
 
     def _is_check_scores_enabled(self, player: Player) -> str | None:
         if self.status != "playing":

--- a/server/games/yahtzee/game.py
+++ b/server/games/yahtzee/game.py
@@ -11,9 +11,16 @@ import random
 
 from ..base import Game, Player, GameOptions
 from ..registry import register_game
+from ...game_utils.action_guard_mixin import ActionGuardMixin
 from ...game_utils.actions import Action, ActionSet, Visibility
 from ...game_utils.bot_helper import BotHelper
-from ...game_utils.dice import DiceSet
+from ...game_utils.dice import (
+    DiceSet,
+    count_dice,
+    has_consecutive_run,
+    has_full_house,
+    has_n_of_a_kind,
+)
 from ...game_utils.dice_game_mixin import DiceGameMixin
 from ...game_utils.game_result import GameResult, PlayerResult
 from ...game_utils.options import IntOption, option_field
@@ -60,16 +67,6 @@ UPPER_VALUES = {
     "fives": 5,
     "sixes": 6,
 }
-
-
-def count_dice(dice: list[int]) -> dict[int, int]:
-    """Count occurrences of each die value (1-6)."""
-    counts = {i: 0 for i in range(1, 7)}
-    for die in dice:
-        counts[die] += 1
-    return counts
-
-
 def calculate_score(dice: list[int], category: str) -> int:
     """Calculate the score for a category given the dice."""
     if not dice or len(dice) != 5:
@@ -85,49 +82,39 @@ def calculate_score(dice: list[int], category: str) -> int:
 
     # Three of a Kind - sum of all if 3+ of same
     if category == "three_kind":
-        if any(c >= 3 for c in counts.values()):
+        if has_n_of_a_kind(counts, 3):
             return dice_sum
         return 0
 
     # Four of a Kind - sum of all if 4+ of same
     if category == "four_kind":
-        if any(c >= 4 for c in counts.values()):
+        if has_n_of_a_kind(counts, 4):
             return dice_sum
         return 0
 
     # Full House - 3 of one kind + 2 of another = 25 points
     if category == "full_house":
-        has_three = any(c == 3 for c in counts.values())
-        has_two = any(c == 2 for c in counts.values())
-        # Also allow 5 of a kind as full house
-        has_five = any(c == 5 for c in counts.values())
-        if (has_three and has_two) or has_five:
+        if has_full_house(counts, allow_five_kind=True):
             return 25
         return 0
 
     # Small Straight - 4 consecutive = 30 points
     if category == "small_straight":
-        # Check for 1-2-3-4, 2-3-4-5, or 3-4-5-6
-        straights = [
-            {1, 2, 3, 4},
-            {2, 3, 4, 5},
-            {3, 4, 5, 6},
-        ]
-        dice_set = set(dice)
-        if any(s.issubset(dice_set) for s in straights):
+        if has_consecutive_run(counts, length=4, min_value=1, max_value=6):
             return 30
         return 0
 
     # Large Straight - 5 consecutive = 40 points
     if category == "large_straight":
-        sorted_dice = sorted(dice)
-        if sorted_dice == [1, 2, 3, 4, 5] or sorted_dice == [2, 3, 4, 5, 6]:
+        if has_consecutive_run(
+            counts, length=5, min_value=1, max_value=6, require_unique=True
+        ):
             return 40
         return 0
 
     # Yahtzee - 5 of a kind = 50 points
     if category == "yahtzee":
-        if any(c == 5 for c in counts.values()):
+        if has_n_of_a_kind(counts, 5):
             return 50
         return 0
 
@@ -211,7 +198,7 @@ class YahtzeeOptions(GameOptions):
 
 @dataclass
 @register_game
-class YahtzeeGame(Game, DiceGameMixin):
+class YahtzeeGame(ActionGuardMixin, Game, DiceGameMixin):
     """
     Yahtzee dice game.
 
@@ -336,12 +323,9 @@ class YahtzeeGame(Game, DiceGameMixin):
 
     def _is_roll_enabled(self, player: Player) -> str | None:
         """Check if roll action is enabled."""
-        if self.status != "playing":
-            return "action-not-playing"
-        if self.current_player != player:
-            return "action-not-your-turn"
-        if player.is_spectator:
-            return "action-spectator"
+        error = self.guard_turn_action_enabled(player)
+        if error:
+            return error
         ytz_player: YahtzeePlayer = player  # type: ignore
         if ytz_player.rolls_left <= 0:
             return "yahtzee-no-rolls-left"
@@ -349,14 +333,10 @@ class YahtzeeGame(Game, DiceGameMixin):
 
     def _is_roll_hidden(self, player: Player) -> Visibility:
         """Check if roll action is hidden."""
-        if self.status != "playing":
-            return Visibility.HIDDEN
-        if self.current_player != player:
-            return Visibility.HIDDEN
         ytz_player: YahtzeePlayer = player  # type: ignore
-        if ytz_player.rolls_left <= 0:
-            return Visibility.HIDDEN
-        return Visibility.VISIBLE
+        return self.turn_action_visibility(
+            player, extra_condition=ytz_player.rolls_left > 0
+        )
 
     def _get_roll_label(self, player: Player, action_id: str) -> str:
         """Get dynamic label for roll action."""
@@ -369,10 +349,9 @@ class YahtzeeGame(Game, DiceGameMixin):
 
     def _is_dice_toggle_enabled(self, player: Player, die_index: int) -> str | None:
         """Check if toggling die at index is enabled (override from DiceGameMixin)."""
-        if self.status != "playing":
-            return "action-not-playing"
-        if self.current_player != player:
-            return "action-not-your-turn"
+        error = self.guard_turn_action_enabled(player)
+        if error:
+            return error
         ytz_player: YahtzeePlayer = player  # type: ignore
         if not ytz_player.dice.has_rolled:
             return "dice-not-rolled"
@@ -382,22 +361,13 @@ class YahtzeeGame(Game, DiceGameMixin):
 
     def _is_dice_toggle_hidden(self, player: Player, die_index: int) -> Visibility:
         """Check if die toggle action is hidden (override from DiceGameMixin)."""
-        if self.status != "playing":
-            return Visibility.HIDDEN
-        if self.current_player != player:
-            return Visibility.HIDDEN
         ytz_player: YahtzeePlayer = player  # type: ignore
-        if not ytz_player.dice.has_rolled:
-            return Visibility.HIDDEN
-        if ytz_player.rolls_left <= 0:
-            return Visibility.HIDDEN
-        return Visibility.VISIBLE
+        extra_condition = ytz_player.dice.has_rolled and ytz_player.rolls_left > 0
+        return self.turn_action_visibility(player, extra_condition=extra_condition)
 
     def _is_view_dice_enabled(self, player: Player) -> str | None:
         """Check if view dice action is enabled."""
-        if self.status != "playing":
-            return "action-not-playing"
-        return None
+        return self.guard_game_active()
 
     def _is_view_dice_hidden(self, player: Player) -> Visibility:
         """View dice is always hidden from menu (keybind only)."""
@@ -405,9 +375,7 @@ class YahtzeeGame(Game, DiceGameMixin):
 
     def _is_view_scoresheet_enabled(self, player: Player) -> str | None:
         """Check if view scoresheet action is enabled."""
-        if self.status != "playing":
-            return "action-not-playing"
-        return None
+        return self.guard_game_active()
 
     def _is_view_scoresheet_hidden(self, player: Player) -> Visibility:
         """View scoresheet is always hidden from menu (keybind only)."""
@@ -936,12 +904,9 @@ class YahtzeeGame(Game, DiceGameMixin):
 def _make_score_enabled(cat: str):
     """Create an is_enabled method for a scoring category."""
     def method(self, player: Player) -> str | None:
-        if self.status != "playing":
-            return "action-not-playing"
-        if self.current_player != player:
-            return "action-not-your-turn"
-        if player.is_spectator:
-            return "action-spectator"
+        error = self.guard_turn_action_enabled(player)
+        if error:
+            return error
         if not player.dice.has_rolled:
             return "yahtzee-roll-first"
         if cat not in player.get_open_categories():
@@ -953,15 +918,8 @@ def _make_score_enabled(cat: str):
 def _make_score_hidden(cat: str):
     """Create an is_hidden method for a scoring category."""
     def method(self, player: Player) -> Visibility:
-        if self.status != "playing":
-            return Visibility.HIDDEN
-        if self.current_player != player:
-            return Visibility.HIDDEN
-        if not player.dice.has_rolled:
-            return Visibility.HIDDEN
-        if cat not in player.get_open_categories():
-            return Visibility.HIDDEN
-        return Visibility.VISIBLE
+        extra_condition = player.dice.has_rolled and cat in player.get_open_categories()
+        return self.turn_action_visibility(player, extra_condition=extra_condition)
     return method
 
 


### PR DESCRIPTION
## Summary
- Move dice-counting/combination helpers plus action guard logic into shared modules used by every dice game.
- Add PushYourLuckBotMixin + TeamResultBuilder so Pig/Toss Up share bot targeting and end-screen formatting.

## Testing
- uv run pytest tests/test_yahtzee.py
- uv run pytest tests/test_pig.py
- uv run pytest

Fixes #92