### PR TITLE
Speed up localization startup and add caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 server/.ruff_cache
 server/.pytest_cache
 server/errors.log
+server/.cache/
 server/playpalace.db
 server/config.toml
 

--- a/server/core/server.py
+++ b/server/core/server.py
@@ -1,6 +1,7 @@
 """Main server class that ties everything together."""
 
 import asyncio
+import contextlib
 import logging
 import os
 import shutil
@@ -90,6 +91,7 @@ class Server(AdministrationMixin):
         ssl_cert: str | Path | None = None,
         ssl_key: str | Path | None = None,
         config_path: str | Path | None = None,
+        preload_locales: bool = False,
     ):
         """Initialize the server and core managers.
 
@@ -101,6 +103,7 @@ class Server(AdministrationMixin):
             ssl_cert: Optional SSL certificate path for TLS.
             ssl_key: Optional SSL private key path for TLS.
             config_path: Optional config.toml path override.
+            preload_locales: Whether to block startup while compiling all locales.
         """
         self.host = host
         self.port = port
@@ -124,6 +127,7 @@ class Server(AdministrationMixin):
 
         # Virtual bot manager
         self._virtual_bots = VirtualBotManager(self)
+        self._localization_warmup_task: asyncio.Task | None = None
 
         # Credential limits (overridable via config)
         self._username_min_length = DEFAULT_USERNAME_MIN_LENGTH
@@ -133,6 +137,7 @@ class Server(AdministrationMixin):
         self._ws_max_message_size = DEFAULT_WS_MAX_MESSAGE_BYTES
         self._config_path = Path(config_path) if config_path else _MODULE_DIR / "config.toml"
         self._allow_insecure_ws = False
+        self._preload_locales = preload_locales
         self._login_ip_limit = DEFAULT_LOGIN_ATTEMPTS_PER_MINUTE
         self._login_user_limit = DEFAULT_LOGIN_FAILURES_PER_MINUTE
         self._registration_ip_limit = DEFAULT_REGISTRATION_ATTEMPTS_PER_MINUTE
@@ -155,7 +160,6 @@ class Server(AdministrationMixin):
                     provided_locales = candidate
             resolved_locales = provided_locales
         Localization.init(resolved_locales)
-        Localization.preload_bundles()
 
     async def start(self) -> None:
         """Start the server."""
@@ -177,6 +181,8 @@ class Server(AdministrationMixin):
                     file=sys.stderr,
                 )
                 raise SystemExit(1)
+
+        await self._preload_locales_if_requested()
 
         # Enforce transport requirements before bringing up listeners
         self._validate_transport_security()
@@ -230,10 +236,17 @@ class Server(AdministrationMixin):
 
         protocol = "wss" if self._ssl_cert else "ws"
         print(f"Server running on {protocol}://{self.host}:{self.port}")
+        self._start_localization_warmup()
 
     async def stop(self) -> None:
         """Stop the server."""
         print("Stopping server...")
+
+        if self._localization_warmup_task:
+            self._localization_warmup_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._localization_warmup_task
+            self._localization_warmup_task = None
 
         # Save all tables
         self._save_tables()
@@ -478,6 +491,38 @@ class Server(AdministrationMixin):
             "to create an initial administrator before exposing this server on the network. "
             f"Set {BOOTSTRAP_WARNING_ENV}=1 to suppress this warning for CI or local testing."
         )
+
+    def _start_localization_warmup(self) -> None:
+        """Kick off localization compilation in the background."""
+        if self._preload_locales:
+            return
+        if self._localization_warmup_task:
+            return
+        loop = asyncio.get_running_loop()
+        self._localization_warmup_task = loop.create_task(self._warm_locales_async())
+        print(
+            "Localization bundles compiling in background "
+            "(pass --preload-locales to block startup until finished)."
+        )
+
+    async def _warm_locales_async(self) -> None:
+        """Compile all locale bundles without blocking startup."""
+        logger = logging.getLogger("playpalace")
+        try:
+            await asyncio.to_thread(Localization.preload_bundles)
+            print("Localization bundles compiled.")
+        except SystemExit:
+            logger.warning("Localization preload aborted due to configuration error.")
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            logger.exception("Localization preload failed")
+
+    async def _preload_locales_if_requested(self) -> None:
+        """Synchronously compile locales when preload flag is set."""
+        if not self._preload_locales:
+            return
+        await asyncio.to_thread(Localization.preload_bundles)
 
     def _load_tables(self) -> None:
         """Load tables from database and restore their games."""
@@ -3155,6 +3200,7 @@ async def run_server(
     port: int = 8000,
     ssl_cert: str | Path | None = None,
     ssl_key: str | Path | None = None,
+    preload_locales: bool = False,
 ) -> None:
     """Run the server.
 
@@ -3163,6 +3209,7 @@ async def run_server(
         port: Port number to listen on
         ssl_cert: Path to SSL certificate file (for WSS support)
         ssl_key: Path to SSL private key file (for WSS support)
+        preload_locales: Whether to block on localization compilation.
     """
     logging.basicConfig(
         filename="errors.log",
@@ -3323,6 +3370,7 @@ async def run_server(
         ssl_cert=ssl_cert,
         ssl_key=ssl_key,
         db_path=str(db_path),
+        preload_locales=preload_locales,
     )
     await server.start()
 

--- a/server/main.py
+++ b/server/main.py
@@ -59,6 +59,11 @@ Examples:
         dest="ssl_key",
         help="Path to SSL private key file. For Let's Encrypt, use privkey.pem",
     )
+    parser.add_argument(
+        "--preload-locales",
+        action="store_true",
+        help="Block startup until all localization bundles compile (default: warm in background).",
+    )
 
     args = parser.parse_args()
 
@@ -75,6 +80,7 @@ Examples:
             port=args.port,
             ssl_cert=args.ssl_cert,
             ssl_key=args.ssl_key,
+            preload_locales=args.preload_locales,
         )
     )
 

--- a/server/messages/localization.py
+++ b/server/messages/localization.py
@@ -1,10 +1,23 @@
 """Localization system using Mozilla Fluent."""
 
+import builtins
+import hashlib
+import os
+import pickle
 import sys
 from pathlib import Path
 
-from fluent_compiler.bundle import FluentBundle
+from babel import Locale, plural
+from babel.core import UnknownLocaleError
 from babel.lists import format_list
+from fluent_compiler import runtime
+from fluent_compiler.bundle import FluentBundle
+from fluent_compiler.compiler import (
+    LOCALE_NAME,
+    PLURAL_FORM_FOR_NUMBER_NAME,
+    compile_messages,
+)
+from fluent_compiler.resource import FtlResource
 
 
 class Localization:
@@ -17,12 +30,20 @@ class Localization:
 
     _bundles: dict[str, FluentBundle] = {}
     _locales_dir: Path | None = None
+    _cache_dir: Path | None = None
+    _cache_enabled: bool = True
+    _CACHE_VERSION = "1"
+    _CACHE_DISABLE_ENV = "PLAYPALACE_DISABLE_LOCALE_CACHE"
+    _CACHE_DIR_ENV = "PLAYPALACE_LOCALE_CACHE_DIR"
 
     @classmethod
     def init(cls, locales_dir: Path | str) -> None:
         """Initialize the localization system with a locales directory."""
         cls._locales_dir = Path(locales_dir)
         cls._bundles = {}
+        disable_cache = os.environ.get(cls._CACHE_DISABLE_ENV, "").strip().lower()
+        cls._cache_enabled = disable_cache not in {"1", "true", "yes", "on"}
+        cls._cache_dir = None
 
     @classmethod
     def preload_bundles(cls) -> None:
@@ -82,22 +103,181 @@ class Localization:
                 )
                 raise SystemExit(1)
 
-        # Load all .ftl files in the locale directory
-        ftl_content = []
-        for ftl_file in locale_dir.glob("*.ftl"):
-            ftl_content.append(ftl_file.read_text(encoding="utf-8"))
+        payloads, fingerprint = cls._load_locale_payloads(locale_dir, actual_locale)
+        bundle = cls._load_bundle_from_cache(actual_locale, fingerprint)
+        if bundle is None:
+            bundle = cls._compile_bundle(actual_locale, payloads, fingerprint)
+        cls._bundles[locale] = bundle
+        return bundle
 
-        if not ftl_content:
+    @classmethod
+    def _load_locale_payloads(cls, locale_dir: Path, actual_locale: str) -> tuple[list[str], str]:
+        """Read locale files and compute a content fingerprint."""
+        ftl_files = sorted(locale_dir.glob("*.ftl"))
+        if not ftl_files:
             print(
                 f"ERROR: No .ftl localization files found in {locale_dir}.",
                 file=sys.stderr,
             )
             raise SystemExit(1)
 
-        # Compile messages - join all content (use actual locale for bundle)
-        bundle = FluentBundle.from_string(actual_locale, "\n".join(ftl_content))
-        cls._bundles[locale] = bundle
+        digest = hashlib.sha256()
+        digest.update(cls._CACHE_VERSION.encode("utf-8"))
+        digest.update(actual_locale.encode("utf-8"))
+
+        payloads: list[str] = []
+        for ftl_file in ftl_files:
+            text = ftl_file.read_text(encoding="utf-8")
+            payloads.append(text)
+            encoded = text.encode("utf-8")
+            digest.update(ftl_file.name.encode("utf-8"))
+            digest.update(len(encoded).to_bytes(8, "big", signed=False))
+            digest.update(hashlib.sha256(encoded).digest())
+
+        return payloads, digest.hexdigest()
+
+    @classmethod
+    def _load_bundle_from_cache(cls, actual_locale: str, fingerprint: str) -> FluentBundle | None:
+        """Load a cached bundle when available."""
+        cache_root = cls._resolve_cache_dir()
+        if cache_root is None:
+            return None
+
+        cache_path = cache_root / actual_locale / f"{fingerprint}.pkl"
+        if not cache_path.exists():
+            return None
+
+        try:
+            with cache_path.open("rb") as fh:
+                payload = pickle.load(fh)
+            if payload.get("version") != cls._CACHE_VERSION:
+                raise ValueError("Cache version mismatch")
+            module_ast = payload["module_ast"]
+            function_names = payload["function_names"]
+            errors = payload.get("errors", [])
+            compiled_messages = cls._rebuild_compiled_messages(actual_locale, module_ast, function_names)
+        except Exception:
+            try:
+                cache_path.unlink()
+            except FileNotFoundError:
+                pass
+            return None
+
+        bundle = object.__new__(FluentBundle)
+        bundle.locale = actual_locale
+        bundle._compiled_messages = compiled_messages
+        bundle._compilation_errors = errors
         return bundle
+
+    @classmethod
+    def _rebuild_compiled_messages(
+        cls,
+        actual_locale: str,
+        module_ast,
+        function_names: dict[str, str],
+    ) -> dict[str, object]:
+        """Rebuild compiled message functions from cached AST."""
+        module_globals = cls._build_module_globals(actual_locale)
+        code_obj = compile(module_ast, f"<fluent:{actual_locale}>", "exec")
+        exec(code_obj, module_globals)
+        compiled_messages: dict[str, object] = {}
+        for message_id, function_name in function_names.items():
+            func = module_globals.get(function_name)
+            if func is None:
+                raise RuntimeError(f"Missing cached function '{function_name}' for locale '{actual_locale}'.")
+            compiled_messages[message_id] = func
+        return compiled_messages
+
+    @classmethod
+    def _compile_bundle(cls, actual_locale: str, payloads: list[str], fingerprint: str) -> FluentBundle:
+        """Compile locale files and persist cache entry."""
+        resources = [FtlResource.from_string(text) for text in payloads]
+        compiled = compile_messages(actual_locale, resources)
+        bundle = object.__new__(FluentBundle)
+        bundle.locale = actual_locale
+        bundle._compiled_messages = compiled.message_functions
+        bundle._compilation_errors = compiled.errors
+        cls._write_cache_entry(actual_locale, fingerprint, compiled)
+        return bundle
+
+    @classmethod
+    def _resolve_cache_dir(cls) -> Path | None:
+        """Resolve (or create) the cache directory."""
+        if not cls._cache_enabled:
+            return None
+        if cls._cache_dir is not None:
+            return cls._cache_dir
+        base = os.environ.get(cls._CACHE_DIR_ENV)
+        if base:
+            path = Path(base)
+        elif cls._locales_dir is not None:
+            path = cls._locales_dir.parent / ".cache" / "locales"
+        else:
+            return None
+        path.mkdir(parents=True, exist_ok=True)
+        cls._cache_dir = path
+        return cls._cache_dir
+
+    @classmethod
+    def _write_cache_entry(cls, actual_locale: str, fingerprint: str, compiled) -> None:
+        """Persist compiled bundle artifacts for reuse."""
+        if compiled.module_ast is None:
+            return
+        cache_root = cls._resolve_cache_dir()
+        if cache_root is None:
+            return
+        entry_dir = cache_root / actual_locale
+        entry_dir.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "version": cls._CACHE_VERSION,
+            "fingerprint": fingerprint,
+            "locale": actual_locale,
+            "function_names": {msg_id: func.__name__ for msg_id, func in compiled.message_functions.items()},
+            "module_ast": compiled.module_ast,
+            "errors": compiled.errors,
+        }
+        tmp_path = entry_dir / f"{fingerprint}.tmp"
+        final_path = entry_dir / f"{fingerprint}.pkl"
+        with tmp_path.open("wb") as fh:
+            pickle.dump(payload, fh)
+        os.replace(tmp_path, final_path)
+        for cached in entry_dir.glob("*.pkl"):
+            if cached == final_path:
+                continue
+            try:
+                cached.unlink()
+            except OSError:
+                pass
+
+    @classmethod
+    def _build_module_globals(cls, locale_name: str) -> dict[str, object]:
+        """Recreate the runtime globals used by fluent_compiler."""
+        module_globals = {name: getattr(runtime, name) for name in runtime.__all__}
+        module_globals.update(builtins.__dict__)
+        module_globals["__builtins__"] = builtins.__dict__
+        babel_locale = cls._parse_locale(locale_name)
+        plural_func = plural.to_python(babel_locale.plural_form)
+
+        def plural_form_for_number(number):
+            try:
+                return plural_func(number)
+            except TypeError:
+                return None
+
+        module_globals[PLURAL_FORM_FOR_NUMBER_NAME] = plural_form_for_number
+        module_globals[LOCALE_NAME] = babel_locale
+        module_globals["__name__"] = f"fluent_cache_{locale_name}"
+        module_globals["__package__"] = None
+        return module_globals
+
+    @staticmethod
+    def _parse_locale(locale_name: str) -> Locale:
+        """Parse a locale string, defaulting to English on error."""
+        normalized = locale_name.replace("-", "_")
+        try:
+            return Locale.parse(normalized)
+        except (ValueError, UnknownLocaleError):
+            return Locale.parse("en")
 
     # Unicode bidi isolation characters that Fluent adds around variables
     _BIDI_CHARS = "\u2068\u2069"  # FIRST STRONG ISOLATE, POP DIRECTIONAL ISOLATE

--- a/server/tests/test_localization_cache.py
+++ b/server/tests/test_localization_cache.py
@@ -1,0 +1,97 @@
+import asyncio
+from pathlib import Path
+
+import pytest
+
+import server.core.server as core_server
+from server.core.server import Server
+from server.messages.localization import Localization
+
+
+def _write_locale(locale_root: Path, content: str) -> None:
+    locale_dir = locale_root / "en"
+    locale_dir.mkdir(parents=True, exist_ok=True)
+    (locale_dir / "main.ftl").write_text(
+        "hello = " + content + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_localization_cache_refreshes_on_file_change(tmp_path, monkeypatch):
+    locales_dir = tmp_path / "locales"
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setenv("PLAYPALACE_LOCALE_CACHE_DIR", str(cache_dir))
+    monkeypatch.delenv("PLAYPALACE_DISABLE_LOCALE_CACHE", raising=False)
+
+    _write_locale(locales_dir, "Hi")
+    Localization.init(locales_dir)
+    assert Localization.get("en", "hello") == "Hi"
+    cache_files = list((cache_dir / "en").glob("*.pkl"))
+    assert len(cache_files) == 1
+    first_cache = cache_files[0].name
+
+    _write_locale(locales_dir, "Hello again")
+    Localization.init(locales_dir)
+    assert Localization.get("en", "hello") == "Hello again"
+    cache_files = list((cache_dir / "en").glob("*.pkl"))
+    assert len(cache_files) == 1
+    assert cache_files[0].name != first_cache
+
+
+def test_localization_cache_can_be_disabled(tmp_path, monkeypatch):
+    locales_dir = tmp_path / "locales"
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setenv("PLAYPALACE_LOCALE_CACHE_DIR", str(cache_dir))
+    monkeypatch.setenv("PLAYPALACE_DISABLE_LOCALE_CACHE", "true")
+
+    _write_locale(locales_dir, "Hi")
+    Localization.init(locales_dir)
+    Localization.get("en", "hello")
+
+    assert not cache_dir.exists()
+
+
+@pytest.mark.asyncio
+async def test_localization_background_warmup_logs(monkeypatch, capsys):
+    calls: list[str] = []
+
+    def fake_preload():
+        calls.append("preload")
+
+    async def immediate_to_thread(func, /, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(core_server.Localization, "preload_bundles", fake_preload)
+    monkeypatch.setattr(core_server.asyncio, "to_thread", immediate_to_thread)
+
+    server = Server(host="::1", port=9002, preload_locales=False)
+    server._start_localization_warmup()
+    assert server._localization_warmup_task is not None
+    await asyncio.wait_for(server._localization_warmup_task, timeout=1)
+
+    captured = capsys.readouterr()
+    assert "Localization bundles compiling in background" in captured.out
+    assert "Localization bundles compiled." in captured.out
+    assert calls == ["preload"]
+
+
+@pytest.mark.asyncio
+async def test_localization_preload_flag_blocks(monkeypatch):
+    calls: list[str] = []
+
+    def fake_preload():
+        calls.append("preload")
+
+    async def immediate_to_thread(func, /, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(core_server.Localization, "preload_bundles", fake_preload)
+    monkeypatch.setattr(core_server.asyncio, "to_thread", immediate_to_thread)
+
+    blocking_server = Server(host="::1", port=9003, preload_locales=True)
+    await blocking_server._preload_locales_if_requested()
+    assert calls == ["preload"]
+
+    nonblocking_server = Server(host="::1", port=9004, preload_locales=False)
+    await nonblocking_server._preload_locales_if_requested()
+    assert calls == ["preload"]

--- a/server/tests/test_server_main_cli.py
+++ b/server/tests/test_server_main_cli.py
@@ -1,0 +1,46 @@
+import importlib
+import os
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def main_module():
+    """Import server.main and restore cwd after the test."""
+    original_cwd = os.getcwd()
+    main_mod = importlib.import_module("server.main")
+    try:
+        yield main_mod
+    finally:
+        os.chdir(original_cwd)
+
+
+def _set_argv(monkeypatch, args: list[str]) -> None:
+    monkeypatch.setattr(sys, "argv", ["main.py", *args])
+
+
+def test_main_passes_preload_flag(monkeypatch, main_module):
+    captured = {}
+
+    async def fake_run_server(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(main_module, "run_server", fake_run_server)
+    _set_argv(monkeypatch, ["--preload-locales"])
+    main_module.main()
+
+    assert captured["preload_locales"] is True
+
+
+def test_main_default_preload_false(monkeypatch, main_module):
+    captured = {}
+
+    async def fake_run_server(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(main_module, "run_server", fake_run_server)
+    _set_argv(monkeypatch, [])
+    main_module.main()
+
+    assert captured["preload_locales"] is False


### PR DESCRIPTION
## Summary
- load Fluent bundles lazily, cache compiled ASTs, and warm them in the background with operator logs/options
- expose --preload-locales flag so CI can block until compilation finishes, and wire flag through run_server
- add regression tests for caching, warmup behavior, env toggles, and CLI plumbing

## Testing
- uv run pytest server/tests/test_localization_cache.py server/tests/test_server_main_cli.py

This drops time-to-ready from ~12.1s to ~0.65s on my dev box while still validating bundles after boot.

Closes #108
