### PR TITLE
Add client UI/network regression tests

### DIFF
--- a/client/tests/conftest.py
+++ b/client/tests/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+import wx
+
+
+@pytest.fixture(scope="session")
+def wx_app():
+    """Ensure a wx App exists for dialog tests."""
+    if not wx.App.IsDisplayAvailable():
+        pytest.skip("GUI display is not available for wx dialogs")
+    app = wx.App(False)
+    yield app
+    app.Destroy()

--- a/client/tests/test_buffer_system.py
+++ b/client/tests/test_buffer_system.py
@@ -1,0 +1,76 @@
+from buffer_system import BufferSystem
+
+
+def test_add_item_populates_buffer_and_all():
+    buffers = BufferSystem()
+    buffers.create_buffer("all")
+    buffers.create_buffer("activity")
+
+    buffers.add_item("activity", "joined table")
+
+    assert buffers.buffers["activity"][0]["text"] == "joined table"
+    assert buffers.buffers["all"][0]["text"] == "joined table"
+    assert buffers.buffer_positions["activity"] == 0
+
+
+def test_navigation_updates_current_buffer():
+    buffers = BufferSystem()
+    buffers.create_buffer("all")
+    buffers.create_buffer("activity")
+    buffers.create_buffer("chat")
+
+    assert buffers.get_current_buffer_name() == "all"
+    buffers.next_buffer()
+    assert buffers.get_current_buffer_name() == "activity"
+    buffers.next_buffer()
+    buffers.next_buffer()  # should clamp at last buffer
+    assert buffers.get_current_buffer_name() == "chat"
+    buffers.previous_buffer()
+    assert buffers.get_current_buffer_name() == "activity"
+    buffers.first_buffer()
+    assert buffers.get_current_buffer_name() == "all"
+    buffers.last_buffer()
+    assert buffers.get_current_buffer_name() == "chat"
+
+
+def test_move_in_buffer_traverses_messages():
+    buffers = BufferSystem()
+    buffers.create_buffer("all")
+    buffers.create_buffer("activity")
+    for i in range(3):
+        buffers.add_item("activity", f"msg-{i}")
+    buffers.last_buffer()
+    # Default position is newest message index 0
+    assert buffers.get_current_item()["text"] == "msg-2"
+    buffers.move_in_buffer("older")
+    assert buffers.get_current_item()["text"] == "msg-1"
+    buffers.move_in_buffer("oldest")
+    assert buffers.get_current_item()["text"] == "msg-0"
+    buffers.move_in_buffer("newest")
+    assert buffers.get_current_item()["text"] == "msg-2"
+
+
+def test_toggle_mute_and_get_muted_buffers():
+    buffers = BufferSystem()
+    buffers.create_buffer("activity")
+    assert buffers.is_muted("activity") is False
+    buffers.toggle_mute("activity")
+    assert buffers.is_muted("activity") is True
+    assert "activity" in buffers.get_muted_buffers()
+    buffers.toggle_mute("activity")
+    assert buffers.is_muted("activity") is False
+
+
+def test_clear_buffer_and_all_buffers():
+    buffers = BufferSystem()
+    buffers.create_buffer("all")
+    buffers.create_buffer("activity")
+    buffers.add_item("activity", "first")
+    buffers.clear_buffer("activity")
+    assert buffers.buffers["activity"] == []
+    assert buffers.buffer_positions["activity"] == 0
+
+    buffers.add_item("activity", "second")
+    buffers.add_item("activity", "third")
+    buffers.clear_all_buffers()
+    assert all(not buf for buf in buffers.buffers.values())

--- a/client/tests/test_config_manager.py
+++ b/client/tests/test_config_manager.py
@@ -1,0 +1,259 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from config_manager import (
+    ConfigManager,
+    delete_item_from_dict,
+    get_item_from_dict,
+    set_item_in_dict,
+)
+
+
+def write_json(path: Path, data):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data))
+
+
+def make_manager(tmp_path):
+    return ConfigManager(base_path=tmp_path / "pp")
+
+
+def test_get_item_from_dict_create_mode_builds_layers():
+    data = {}
+    result = get_item_from_dict(data, "servers/foo/bar", create_mode=True)
+    assert result == {}
+    assert "servers" in data and "foo" in data["servers"]
+
+
+def test_set_item_in_dict_strict_mode_requires_existing_keys():
+    data = {"section": {}}
+    with pytest.raises(KeyError):
+        set_item_in_dict(data, "section/missing/value", 1, create_mode=False)
+
+    set_item_in_dict(data, "section/value", 2, create_mode=True)
+    assert data["section"]["value"] == 2
+
+
+def test_delete_item_from_dict_cleans_empty_layers():
+    data = {"section": {"nested": {"leaf": 1, "keep": 2}}}
+    assert delete_item_from_dict(data, "section/nested/leaf")
+    assert "leaf" not in data["section"]["nested"]
+    # Remove final value should collapse nested dict
+    assert delete_item_from_dict(data, "section/nested/keep")
+    assert "section" not in data
+
+
+def test_identities_migration_adds_email_field(tmp_path):
+    identities = {
+        "last_server_id": None,
+        "servers": {
+            "server-1": {
+                "accounts": {
+                    "acct-1": {"username": "demo"},
+                }
+            }
+        },
+    }
+    base = tmp_path / "pp"
+    write_json(base / "identities.json", identities)
+    cm = ConfigManager(base_path=base)
+
+    account = cm.identities["servers"]["server-1"]["accounts"]["acct-1"]
+    assert account["email"] == ""
+    persisted = json.loads((base / "identities.json").read_text())
+    assert persisted["servers"]["server-1"]["accounts"]["acct-1"]["email"] == ""
+
+
+def test_invalid_identities_file_returns_defaults(tmp_path):
+    base = tmp_path / "pp"
+    (base / "identities.json").parent.mkdir(parents=True, exist_ok=True)
+    (base / "identities.json").write_text("{not-json")
+
+    cm = ConfigManager(base_path=base)
+    assert cm.identities == cm._get_default_identities()
+
+
+def test_profile_migration_moves_servers_and_languages(tmp_path):
+    profiles = {
+        "client_options_defaults": {
+            "social": {
+                "chat_input_language": "Check",
+                "language_subscriptions": {"Check": True},
+            },
+            "table_creations": {"general": True},
+        },
+        "servers": {
+            "srv-1": {
+                "options_overrides": {
+                    "social": {
+                        "chat_input_language": "Check",
+                        "language_subscriptions": {"Check": True},
+                    },
+                    "table_creations": {"vip": True},
+                }
+            }
+        },
+    }
+    base = tmp_path / "pp"
+    write_json(base / "identities.json", ConfigManager(base)._get_default_identities())
+    write_json(base / "option_profiles.json", profiles)
+
+    cm = ConfigManager(base_path=base)
+    defaults = cm.profiles["client_options_defaults"]
+    assert defaults["social"]["chat_input_language"] == "Czech"
+    assert "creation_notifications" in defaults["local_table"]
+    assert defaults["local_table"]["creation_notifications"] == {"general": True}
+
+    overrides = cm.profiles["server_options"]["srv-1"]
+    assert overrides["social"]["chat_input_language"] == "Czech"
+    assert overrides["social"]["language_subscriptions"] == {"Czech": True}
+    assert overrides["local_table"]["creation_notifications"] == {"vip": True}
+    assert "servers" not in cm.profiles
+
+
+def test_deep_merge_override_behavior(tmp_path):
+    cm = make_manager(tmp_path)
+    base = {"audio": {"volume": 10, "muted": False}, "theme": "light"}
+    override = {"audio": {"volume": 20}, "new": 1}
+
+    merged = cm._deep_merge(base, override, override_wins=True)
+    assert merged["audio"]["volume"] == 20
+    assert merged["audio"]["muted"] is False
+    assert merged["new"] == 1
+
+    merged_base_wins = cm._deep_merge(base, {"audio": {"muted": True}}, override_wins=False)
+    assert merged_base_wins["audio"]["muted"] is False
+
+
+def test_add_update_delete_server(tmp_path):
+    cm = make_manager(tmp_path)
+    server_id = cm.add_server("Local", "localhost", "9000", "notes")
+    assert server_id in cm.get_all_servers()
+
+    cm.update_server(server_id, name="Prod", port="8000")
+    server = cm.get_server_by_id(server_id)
+    assert server["name"] == "Prod"
+    assert server["port"] == "8000"
+
+    assert cm.get_server_display_name(server_id) == "Prod"
+    assert cm.get_server_url(server_id) == "ws://localhost:8000"
+
+    cm.delete_server(server_id)
+    assert server_id not in cm.get_all_servers()
+
+
+def test_get_server_url_respects_existing_scheme(tmp_path):
+    cm = make_manager(tmp_path)
+    server_id = cm.add_server("Secure", "wss://example.com", "9001")
+    assert cm.get_server_url(server_id) == "wss://example.com:9001"
+
+
+def test_last_server_and_accounts(tmp_path):
+    cm = make_manager(tmp_path)
+    server_id = cm.add_server("Local", "localhost", "8000")
+    account_id = cm.add_account(server_id, "alice", "pwd", email="a@example.com")
+    assert cm.get_server_accounts(server_id)
+    cm.update_account(server_id, account_id, password="secret", notes="admin")
+    acct = cm.get_account_by_id(server_id, account_id)
+    assert acct["password"] == "secret"
+    assert acct["notes"] == "admin"
+
+    cm.set_last_server(server_id)
+    cm.set_last_account(server_id, account_id)
+    assert cm.get_last_server_id() == server_id
+    assert cm.get_last_account_id(server_id) == account_id
+
+    cm.delete_account(server_id, account_id)
+    assert cm.get_last_account_id(server_id) is None
+
+
+def test_trusted_certificate_round_trip(tmp_path):
+    cm = make_manager(tmp_path)
+    server_id = cm.add_server("Secure", "example", "8000")
+    assert cm.get_trusted_certificate(server_id) is None
+
+    cert_info = {"fingerprint": "aa:bb", "issued_to": "example"}
+    cm.set_trusted_certificate(server_id, cert_info)
+    assert cm.get_trusted_certificate(server_id) == cert_info
+
+    cm.clear_trusted_certificate(server_id)
+    assert cm.get_trusted_certificate(server_id) is None
+
+    # Unknown server should be a no-op
+    cm.set_trusted_certificate("missing", cert_info)  # Should not raise
+
+
+def test_client_options_with_overrides(tmp_path):
+    cm = make_manager(tmp_path)
+    server_id = cm.add_server("Local", "localhost", "8000")
+
+    cm.set_client_option("audio/music_volume", 25)
+    cm.set_client_option("audio/music_volume", 60, server_id, create_mode=True)
+    defaults = cm.get_client_options()
+    overrides = cm.get_client_options(server_id)
+
+    assert defaults["audio"]["music_volume"] == 25
+    assert overrides["audio"]["music_volume"] == 60
+
+    cm.clear_server_override(server_id, "audio/music_volume")
+    assert cm.get_client_options(server_id)["audio"]["music_volume"] == 25
+
+
+def test_set_client_option_creates_layers(tmp_path):
+    cm = make_manager(tmp_path)
+    cm.set_client_option("social/language_subscriptions/Spanish", True, create_mode=True)
+    defaults = cm.get_client_options()
+    assert defaults["social"]["language_subscriptions"]["Spanish"] is True
+
+
+def test_clear_server_override_prunes_empty_dict(tmp_path):
+    cm = make_manager(tmp_path)
+    server_id = cm.add_server("Local", "localhost", "8000")
+    cm.set_client_option("interface/play_typing_sounds", False, server_id, create_mode=True)
+    cm.clear_server_override(server_id, "interface/play_typing_sounds", delete_empty_layers=True)
+    assert cm.profiles["server_options"][server_id] == {}
+
+
+def test_profiles_migration_converts_legacy_servers(tmp_path):
+    base = tmp_path / "pp"
+    helper = ConfigManager(base_path=base)
+    legacy_profiles = helper._get_default_profiles()
+    legacy_profiles["client_options_defaults"]["table_creations"] = {"general": True}
+    legacy_profiles["servers"] = {
+        "srv-legacy": {
+            "options_overrides": {
+                "social": {
+                    "chat_input_language": "Check",
+                    "language_subscriptions": {"Check": True},
+                },
+                "table_creations": {"vip": True},
+            }
+        }
+    }
+    legacy_profiles.pop("server_options", None)
+    profiles_path = base / "option_profiles.json"
+    profiles_path.parent.mkdir(parents=True, exist_ok=True)
+    profiles_path.write_text(json.dumps(legacy_profiles))
+
+    migrated = ConfigManager(base_path=base)
+    assert "servers" not in migrated.profiles
+    overrides = migrated.profiles["server_options"]["srv-legacy"]
+    assert overrides["social"]["chat_input_language"] == "Czech"
+    assert overrides["social"]["language_subscriptions"] == {"Czech": True}
+    assert overrides["local_table"]["creation_notifications"] == {"vip": True}
+    defaults = migrated.profiles["client_options_defaults"]
+    assert defaults["local_table"]["creation_notifications"] == {"general": True}
+
+
+def test_invalid_profiles_file_returns_defaults(tmp_path):
+    base = tmp_path / "pp"
+    helper = ConfigManager(base_path=base)
+    defaults = helper._get_default_profiles()
+    profiles_path = base / "option_profiles.json"
+    profiles_path.parent.mkdir(parents=True, exist_ok=True)
+    profiles_path.write_text("{not-json")
+
+    cm = ConfigManager(base_path=base)
+    assert cm.profiles == defaults

--- a/client/tests/test_main_window_packets.py
+++ b/client/tests/test_main_window_packets.py
@@ -1,0 +1,196 @@
+import types
+
+import pytest
+
+from ui import main_window as main_mod
+
+
+class StubMenuList:
+    def __init__(self):
+        self.items = []
+        self.selection = main_mod.wx.NOT_FOUND
+        self.client_data = {}
+        self.multiletter = True
+        self.grid = (False, 1)
+
+    def Clear(self):
+        self.items.clear()
+        self.selection = main_mod.wx.NOT_FOUND
+
+    def Append(self, text):
+        self.items.append(text)
+
+    def GetCount(self):
+        return len(self.items)
+
+    def GetString(self, index):
+        return self.items[index]
+
+    def SetString(self, index, text):
+        self.items[index] = text
+
+    def Delete(self, index):
+        del self.items[index]
+
+    def Insert(self, text, index):
+        self.items.insert(index, text)
+
+    def SetSelection(self, index):
+        self.selection = index
+
+    def GetSelection(self):
+        return self.selection
+
+    def SetClientData(self, index, data):
+        self.client_data[index] = data
+
+    def enable_multiletter_navigation(self, enabled):
+        self.multiletter = enabled
+
+    def enable_grid_mode(self, enabled, grid_width):
+        self.grid = (enabled, grid_width)
+
+    def SetFocus(self):
+        pass
+
+    def Hide(self):
+        pass
+
+    def Show(self):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def no_focus(monkeypatch):
+    class DummyWindow:
+        @classmethod
+        def FindFocus(cls):
+            return None
+
+    monkeypatch.setattr(main_mod.wx, "Window", DummyWindow)
+
+
+def make_window():
+    window = main_mod.MainWindow.__new__(main_mod.MainWindow)
+    window.menu_list = StubMenuList()
+    window.chat_input = object()
+    window.history_text = object()
+    window.sound_manager = types.SimpleNamespace(
+        remove_all_playlists=lambda: window.sound_events.append("remove"),
+        stop_music=lambda fade=True: window.sound_events.append(f"stop_music:{fade}"),
+        stop_ambience=lambda force=False: window.sound_events.append(f"stop_ambience:{force}"),
+    )
+    window.sound_events = []
+    window.network = types.SimpleNamespace(send_packet=lambda packet: window.sent_packets.append(packet))
+    window.sent_packets = []
+    window.buffer_system = types.SimpleNamespace()
+    window.current_mode = "list"
+    window.current_menu_id = None
+    window.current_menu_state = None
+    window.current_menu_item_ids = []
+    window.switch_to_list_mode = lambda: setattr(window, "current_mode", "list")
+    window.switch_to_edit_mode = lambda *args, **kwargs: None
+    window.set_multiletter_navigation = main_mod.MainWindow.set_multiletter_navigation.__get__(window)
+    window.set_grid_mode = main_mod.MainWindow.set_grid_mode.__get__(window)
+    window.on_server_clear_ui = main_mod.MainWindow.on_server_clear_ui.__get__(window)
+    window.on_server_menu = main_mod.MainWindow.on_server_menu.__get__(window)
+    window.on_server_request_input = main_mod.MainWindow.on_server_request_input.__get__(window)
+    window.on_server_clear_ui = main_mod.MainWindow.on_server_clear_ui.__get__(window)
+    window.switch_to_edit_mode_calls = []
+
+    def fake_switch_to_edit_mode(prompt, callback, default, multiline, read_only):
+        window.switch_to_edit_mode_calls.append(
+            {
+                "prompt": prompt,
+                "default": default,
+                "multiline": multiline,
+                "read_only": read_only,
+                "callback": callback,
+            }
+        )
+
+    window.switch_to_edit_mode = fake_switch_to_edit_mode
+    return window
+
+
+def test_on_server_menu_builds_new_menu():
+    window = make_window()
+    packet = {
+        "menu_id": "main",
+        "items": [
+            {"text": "Play", "id": "play", "sound": "click.ogg"},
+            {"text": "Options", "id": "options"},
+        ],
+        "position": 1,
+        "multiletter_enabled": False,
+        "grid_enabled": True,
+        "grid_width": 2,
+    }
+
+    window.on_server_menu(packet)
+
+    assert window.menu_list.items == ["Play", "Options"]
+    assert window.menu_list.selection == 1
+    assert window.menu_list.client_data[0] == {"sound": "click.ogg"}
+    assert window.current_menu_id == "main"
+    assert window.menu_list.multiletter is False
+    assert window.menu_list.grid == (True, 2)
+
+
+def test_on_server_menu_diff_updates_existing_items():
+    window = make_window()
+    window.current_menu_id = "main"
+    window.current_menu_state = {"menu_id": "main", "items": ["Play", "Options"]}
+    window.current_menu_item_ids = ["play", "options"]
+    window.menu_list.items = ["Play", "Options"]
+    window.menu_list.selection = 0
+
+    packet = {
+        "menu_id": "main",
+        "items": [
+            {"text": "Play", "id": "play"},
+            {"text": "Quit", "id": "quit"},
+        ],
+        "selection_id": "quit",
+    }
+
+    window.on_server_menu(packet)
+
+    assert window.menu_list.items == ["Play", "Quit"]
+    assert window.menu_list.selection == 1
+
+
+def test_on_server_request_input_switches_to_edit_mode_and_sends_packet():
+    window = make_window()
+    packet = {
+        "type": "request_input",
+        "prompt": "Enter name",
+        "input_id": "invite",
+        "default_value": "Alice",
+        "multiline": True,
+        "read_only": False,
+    }
+
+    window.on_server_request_input(packet)
+
+    assert window.switch_to_edit_mode_calls
+    call = window.switch_to_edit_mode_calls[-1]
+    assert call["prompt"] == "Enter name"
+    assert call["default"] == "Alice"
+    assert call["multiline"] is True
+    callback = call["callback"]
+    callback("hello")
+    assert window.sent_packets[-1] == {"type": "editbox", "text": "hello", "input_id": "invite"}
+
+
+def test_on_server_clear_ui_resets_menu_and_audio():
+    window = make_window()
+    window.menu_list.items = ["A"]
+    window.current_mode = "edit"
+
+    window.on_server_clear_ui({})
+
+    assert window.menu_list.items == []
+    assert window.current_menu_id is None
+    assert window.current_mode == "list"
+    assert window.sound_events == ["remove", "stop_music:True", "stop_ambience:False"]

--- a/client/tests/test_main_window_startup.py
+++ b/client/tests/test_main_window_startup.py
@@ -1,0 +1,179 @@
+import types
+
+import pytest
+
+from ui import main_window as main_mod
+
+
+class DummySoundManager:
+    def __init__(self):
+        self.play_calls = []
+        self.music_calls = []
+        self.stop_calls = []
+
+    def play(self, name, volume=1.0):
+        self.play_calls.append((name, volume))
+
+    def music(self, name):
+        self.music_calls.append(name)
+
+    def stop_music(self, fade=False):
+        self.stop_calls.append(fade)
+
+    def set_music_volume(self, *_args, **_kwargs):
+        pass
+
+    def set_ambience_volume(self, *_args, **_kwargs):
+        pass
+
+
+class DummyNetworkManager:
+    def __init__(self, should_connect=True):
+        self.calls = []
+        self.should_connect = should_connect
+        self.disconnect_calls = []
+        self.connect_calls = 0
+
+    def connect(self, url, username, password):
+        self.calls.append((url, username, password))
+        self.connect_calls += 1
+        return self.should_connect
+
+    def disconnect(self, wait=False):
+        self.disconnect_calls.append(wait)
+
+
+class DummyCallLater:
+    def __init__(self, delay, callback):
+        self.delay = delay
+        self.callback = callback
+        self.stopped = False
+
+    def Stop(self):
+        self.stopped = True
+
+
+@pytest.fixture(autouse=True)
+def stub_call_later(monkeypatch):
+    created = []
+
+    def fake_call_later(delay, callback, *args, **kwargs):
+        call = DummyCallLater(delay, lambda: callback(*args, **kwargs))
+        created.append(call)
+        return call
+
+    monkeypatch.setattr(main_mod.wx, "CallLater", fake_call_later)
+    yield created
+
+
+def make_window_stub(monkeypatch, should_connect=True):
+    window = main_mod.MainWindow.__new__(main_mod.MainWindow)
+    window.credentials = {
+        "username": "alice",
+        "password": "secret",
+        "server_url": "wss://demo.example:443",
+    }
+    window.server_id = "srv-1"
+    window.config_manager = types.SimpleNamespace(
+        get_client_options=lambda server_id: {"audio": {"music_volume": 40, "ambience_volume": 20}}
+    )
+    window.sound_manager = DummySoundManager()
+    window.network = DummyNetworkManager(should_connect=should_connect)
+    window.expecting_reconnect = False
+    window.returning_to_login = False
+    window.connection_timeout_timer = None
+    window.connected = False
+    window.client_options = {}
+    window.reconnect_attempts = 0
+    window.max_reconnect_attempts = 30
+    window._apply_client_audio_options = lambda: None
+    window.add_history_calls = []
+    window.add_history = lambda text, buffer="misc", *_: window.add_history_calls.append((text, buffer))
+    window._show_connection_error_calls = []
+    window._show_connection_error = lambda message: window._show_connection_error_calls.append(message)
+    window.Close = lambda: None
+    return window
+
+
+def test_auto_connect_uses_credentials(monkeypatch, stub_call_later):
+    window = make_window_stub(monkeypatch, should_connect=True)
+
+    window._auto_connect()
+
+    assert window.sound_manager.music_calls == ["connectloop.ogg"]
+    assert window.add_history_calls[0][0].startswith("Connecting to wss://demo.example:443")
+    assert ("wss://demo.example:443", "alice", "secret") in window.network.calls
+    assert stub_call_later, "CallLater should schedule timeout"
+    assert stub_call_later[0].delay == 10000
+
+
+def test_auto_connect_reports_failure(monkeypatch, stub_call_later):
+    window = make_window_stub(monkeypatch, should_connect=False)
+
+    window._auto_connect()
+
+    assert window.network.calls
+    assert not stub_call_later, "No timeout should be scheduled on failure"
+    assert window._show_connection_error_calls == ["Failed to start connection to server."]
+
+
+def test_check_connection_timeout_triggers_error(monkeypatch):
+    window = make_window_stub(monkeypatch, should_connect=True)
+    window.connection_timeout_timer = None
+    window.expecting_reconnect = False
+    window.returning_to_login = False
+    window.connected = False
+
+    window._check_connection_timeout()
+
+    assert window._show_connection_error_calls == ["Connection timeout: Could not connect to server."]
+
+
+def test_on_server_disconnect_reconnect_flow(monkeypatch, stub_call_later):
+    window = make_window_stub(monkeypatch, should_connect=True)
+    window.connected = False
+    window.speaker = types.SimpleNamespace(speak=lambda *args, **kwargs: None)
+    reconnect_calls = []
+    monkeypatch.setattr(main_mod.wx, "CallLater", lambda delay, func, *args, **kwargs: reconnect_calls.append((delay, func, args, kwargs)))
+
+    window.on_server_disconnect({"reconnect": True})
+
+    assert reconnect_calls, "Reconnection callbacks should be scheduled"
+    delays = [call[0] for call in reconnect_calls]
+    assert 3000 in delays, "Initial reconnect delay expected"
+
+
+def test_do_reconnect_resets_after_max_attempts(monkeypatch):
+    window = make_window_stub(monkeypatch, should_connect=False)
+    window.speaker = types.SimpleNamespace(speak=lambda *args, **kwargs: None)
+    window.expecting_reconnect = True
+
+    for _ in range(window.max_reconnect_attempts + 1):
+        window._do_reconnect("ws://demo", "alice", "secret")
+
+    assert window.expecting_reconnect is False
+    assert window.reconnect_attempts == 0
+
+
+def test_do_reconnect_schedules_followup_when_connecting(monkeypatch, stub_call_later):
+    window = make_window_stub(monkeypatch, should_connect=True)
+    window.expecting_reconnect = True
+    window.speaker = types.SimpleNamespace(speak=lambda *args, **kwargs: None)
+
+    window._do_reconnect("ws://demo", "alice", "secret")
+
+    assert window.network.connect_calls == 1
+    assert stub_call_later[-1].delay == 3000
+
+
+def test_do_reconnect_noop_when_already_connected(monkeypatch, stub_call_later):
+    window = make_window_stub(monkeypatch, should_connect=True)
+    window.connected = True
+    window.expecting_reconnect = True
+    window.speaker = types.SimpleNamespace(speak=lambda *args, **kwargs: None)
+
+    window._do_reconnect("ws://demo", "alice", "secret")
+
+    assert window.expecting_reconnect is False
+    assert window.reconnect_attempts == 0
+    assert not window.network.calls

--- a/client/tests/test_network_manager.py
+++ b/client/tests/test_network_manager.py
@@ -1,0 +1,329 @@
+import asyncio
+import json
+import ssl
+import types
+
+import pytest
+
+import network_manager as nm_mod
+from certificate_prompt import CertificateInfo
+from network_manager import NetworkManager
+
+
+class DummyWebsocket:
+    def __init__(self):
+        self.closed = False
+
+    async def close(self):
+        self.closed = True
+
+
+class DummyConfigManager:
+    def __init__(self):
+        self.set_calls = []
+        self.trusted_entry = None
+
+    def set_trusted_certificate(self, server_id, data):
+        self.set_calls.append((server_id, data))
+        self.trusted_entry = data
+
+    def get_trusted_certificate(self, server_id):
+        return self.trusted_entry
+
+
+class DummyMainWindow:
+    def __init__(self):
+        self.server_id = "server-123"
+        self.config_manager = DummyConfigManager()
+
+
+PACKET_TO_HANDLER = {
+    "authorize_success": "on_authorize_success",
+    "speak": "on_server_speak",
+    "play_sound": "on_server_play_sound",
+    "play_music": "on_server_play_music",
+    "play_ambience": "on_server_play_ambience",
+    "stop_ambience": "on_server_stop_ambience",
+    "add_playlist": "on_server_add_playlist",
+    "start_playlist": "on_server_start_playlist",
+    "remove_playlist": "on_server_remove_playlist",
+    "get_playlist_duration": "on_server_get_playlist_duration",
+    "menu": "on_server_menu",
+    "request_input": "on_server_request_input",
+    "clear_ui": "on_server_clear_ui",
+    "game_list": "on_server_game_list",
+    "disconnect": "on_server_disconnect",
+    "update_options_lists": "on_update_options_lists",
+    "open_client_options": "on_open_client_options",
+    "open_server_options": "on_open_server_options",
+    "table_create": "on_table_create",
+    "pong": "on_server_pong",
+    "chat": "on_receive_chat",
+}
+
+
+class RecordingMainWindow(DummyMainWindow):
+    def __init__(self):
+        super().__init__()
+        self.calls = []
+        self.connection_lost = 0
+        for method in PACKET_TO_HANDLER.values():
+            setattr(self, method, self._build_handler(method))
+
+    def _build_handler(self, method_name):
+        def handler(packet):
+            self.calls.append((method_name, packet.get("type")))
+
+        return handler
+
+    def on_connection_lost(self):
+        self.connection_lost += 1
+
+    def add_history(self, *args, **kwargs):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def callafter_immediate(monkeypatch):
+    monkeypatch.setattr(nm_mod.wx, "CallAfter", lambda func, *a, **k: func(*a, **k))
+
+
+def make_certificate_info(**overrides):
+    defaults = dict(
+        host="example.com",
+        common_name="Example",
+        sans=("example.com",),
+        issuer="CA",
+        valid_from="2025",
+        valid_to="2026",
+        fingerprint="AA:BB",
+        fingerprint_hex="AABB",
+        pem="---",
+        matches_host=True,
+    )
+    defaults.update(overrides)
+    return CertificateInfo(**defaults)
+
+
+def test_verify_pinned_certificate_accepts_matching():
+    nm = NetworkManager(main_window=DummyMainWindow())
+    nm._extract_peer_certificate = lambda ws: ("AABB", {}, "pem")  # type: ignore[attr-defined]
+    nm._get_trusted_certificate_entry = lambda: {"fingerprint": "aabb"}  # type: ignore[attr-defined]
+    ws = DummyWebsocket()
+    asyncio.run(nm._verify_pinned_certificate(ws, "wss://example.com"))
+    assert ws.closed is False
+
+
+def test_verify_pinned_certificate_rejects_mismatch():
+    nm = NetworkManager(main_window=DummyMainWindow())
+    nm._extract_peer_certificate = lambda ws: ("FFFF", {}, "pem")  # type: ignore[attr-defined]
+    nm._get_trusted_certificate_entry = lambda: {"fingerprint": "1111"}  # type: ignore[attr-defined]
+    ws = DummyWebsocket()
+    with pytest.raises(ssl.SSLError):
+        asyncio.run(nm._verify_pinned_certificate(ws, "wss://example.com"))
+    assert ws.closed is True
+
+
+def test_store_and_get_trusted_certificate_round_trip():
+    window = DummyMainWindow()
+    nm = NetworkManager(main_window=window)
+    info = make_certificate_info()
+
+    nm._store_trusted_certificate(info)
+    stored_server, stored_payload = window.config_manager.set_calls[0]
+    assert stored_server == "server-123"
+    assert stored_payload["fingerprint"] == "AABB"
+
+    entry = nm._get_trusted_certificate_entry()
+    assert entry["host"] == "example.com"
+
+
+def test_store_trusted_certificate_noop_without_manager():
+    class NoConfigWindow:
+        server_id = None
+        config_manager = None
+
+    nm = NetworkManager(main_window=NoConfigWindow())
+    nm._store_trusted_certificate(make_certificate_info())
+    assert nm._get_trusted_certificate_entry() is None
+
+
+def test_build_certificate_info_matches_host():
+    nm = NetworkManager(main_window=DummyMainWindow())
+    cert_dict = {
+        "subject": ((("commonName", "example.com"),),),
+        "issuer": ((("organizationName", "Example CA"),),),
+        "subjectAltName": (("DNS", "example.com"), ("DNS", "alt.example.com")),
+        "notBefore": "2025",
+        "notAfter": "2026",
+    }
+    info = nm._build_certificate_info(cert_dict, "AABBCCDDEE1122", pem="", host="example.com")
+    assert info.matches_host is True
+    assert info.fingerprint == "AA:BB:CC:DD:EE:11:22"
+
+
+def test_build_certificate_info_detects_hostname_mismatch():
+    nm = NetworkManager(main_window=DummyMainWindow())
+    cert_dict = {
+        "subject": ((("commonName", "other.example.com"),),),
+        "subjectAltName": (("DNS", "alt.example.com"),),
+        "issuer": (),
+        "notBefore": "",
+        "notAfter": "",
+    }
+    info = nm._build_certificate_info(cert_dict, "ABCD", pem="", host="example.com")
+    assert info.matches_host is False
+    assert info.common_name == "other.example.com"
+
+
+def test_get_server_host_parses_url():
+    nm = NetworkManager(main_window=DummyMainWindow())
+    assert nm._get_server_host("wss://playpalace.example:8443") == "playpalace.example"
+    assert nm._get_server_host("not a url") == ""
+
+
+def test_handle_packet_dispatches_to_main_window():
+    window = RecordingMainWindow()
+    nm = NetworkManager(main_window=window)
+    for packet_type in PACKET_TO_HANDLER:
+        nm._handle_packet({"type": packet_type})
+    assert len(window.calls) == len(PACKET_TO_HANDLER)
+    assert {name for name, _ in window.calls} == set(PACKET_TO_HANDLER.values())
+
+
+def test_send_packet_requires_connection():
+    nm = NetworkManager(main_window=RecordingMainWindow())
+    assert nm.send_packet({"type": "ping"}) is False
+
+
+def test_send_packet_submits_to_loop(monkeypatch):
+    window = RecordingMainWindow()
+    manager = NetworkManager(main_window=window)
+    loop = asyncio.new_event_loop()
+    manager.loop = loop
+    manager.connected = True
+
+    class DummyWebsocket:
+        def __init__(self):
+            self.messages = []
+
+        def send(self, message):
+            self.messages.append(message)
+
+            async def _done():
+                return None
+
+            return _done()
+
+    ws = DummyWebsocket()
+    manager.ws = ws
+
+    def fake_run_coroutine_threadsafe(coro, used_loop):
+        assert used_loop is loop
+        used_loop.run_until_complete(coro)
+
+        class DummyFuture:
+            def result(self, timeout=None):
+                return None
+
+        return DummyFuture()
+
+    monkeypatch.setattr(asyncio, "run_coroutine_threadsafe", fake_run_coroutine_threadsafe)
+    try:
+        assert manager.send_packet({"type": "ping", "data": 1}) is True
+    finally:
+        loop.close()
+
+    assert len(ws.messages) == 1
+    payload = json.loads(ws.messages[0])
+    assert payload["type"] == "ping"
+    assert payload["data"] == 1
+
+
+def test_send_packet_failure_notifies_window(monkeypatch):
+    window = RecordingMainWindow()
+    manager = NetworkManager(main_window=window)
+    manager.connected = True
+    manager.loop = asyncio.new_event_loop()
+    manager.ws = object()
+
+    def fail_run_coroutine_threadsafe(*_):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(asyncio, "run_coroutine_threadsafe", fail_run_coroutine_threadsafe)
+    try:
+        assert manager.send_packet({"type": "ping"}) is False
+    finally:
+        manager.loop.close()
+
+    assert manager.connected is False
+    assert window.connection_lost == 1
+
+
+def test_disconnect_waits_for_thread(monkeypatch):
+    window = RecordingMainWindow()
+    manager = NetworkManager(main_window=window)
+    loop = asyncio.new_event_loop()
+    manager.loop = loop
+    manager.ws = DummyWebsocket()
+    manager.connected = True
+
+    class DummyThread:
+        def __init__(self):
+            self.join_called = False
+            self.alive = True
+
+        def is_alive(self):
+            return self.alive
+
+        def join(self, timeout=None):
+            self.join_called = True
+            self.alive = False
+
+    dummy_thread = DummyThread()
+    manager.thread = dummy_thread
+
+    run_calls = []
+
+    def fake_run_coroutine_threadsafe(coro, used_loop):
+        used_loop.run_until_complete(coro)
+        run_calls.append((coro, used_loop))
+
+        class DummyFuture:
+            def result(self, timeout=None):
+                return None
+
+        return DummyFuture()
+
+    monkeypatch.setattr(asyncio, "run_coroutine_threadsafe", fake_run_coroutine_threadsafe)
+    try:
+        manager.disconnect(wait=True)
+    finally:
+        loop.close()
+
+    assert manager.should_stop is True
+    assert dummy_thread.join_called is True
+    assert run_calls, "Websocket close coroutine should be scheduled"
+
+
+def test_disconnect_without_thread(monkeypatch):
+    manager = NetworkManager(main_window=RecordingMainWindow())
+    manager.loop = asyncio.new_event_loop()
+    manager.ws = DummyWebsocket()
+
+    def fake_threadsafe(coro, used_loop):
+        used_loop.run_until_complete(coro)
+
+        class DummyFuture:
+            def result(self, timeout=None):
+                return None
+
+        return DummyFuture()
+
+    monkeypatch.setattr(asyncio, "run_coroutine_threadsafe", fake_threadsafe)
+    try:
+        manager.disconnect(wait=False)
+    finally:
+        manager.loop.close()
+
+    assert manager.thread is None

--- a/client/tests/test_sound_cacher.py
+++ b/client/tests/test_sound_cacher.py
@@ -1,0 +1,54 @@
+import types
+
+import pytest
+
+import sound_cacher
+from sound_cacher import SoundCacher
+
+
+class DummyStream:
+    def __init__(self, mem, file, length):
+        self._frequency = 44100
+        self.pan = 0.0
+        self.volume = 1.0
+        self.played = False
+        self.mem = mem
+        self.length = length
+
+    def play(self):
+        self.played = True
+
+    def get_frequency(self):
+        return self._frequency
+
+    def set_frequency(self, value):
+        self._frequency = value
+
+
+def test_sound_cacher_returns_stream(monkeypatch, tmp_path):
+    monkeypatch.setattr(sound_cacher, "o", object())
+
+    dummy_stream = DummyStream
+    fake_stream_module = types.SimpleNamespace(FileStream=dummy_stream)
+    monkeypatch.setattr(sound_cacher, "stream", fake_stream_module)
+
+    cache = SoundCacher()
+    audio_file = tmp_path / "beep.ogg"
+    audio_file.write_bytes(b"wave-data")
+
+    stream = cache.play(str(audio_file), pan=0.4, volume=0.6, pitch=1.2)
+
+    assert isinstance(stream, DummyStream)
+    assert stream.played is True
+    assert pytest.approx(stream.pan) == 0.4
+    assert pytest.approx(stream.volume) == 0.6
+    assert pytest.approx(stream.get_frequency()) == int(44100 * 1.2)
+    # Second call should reuse cached bytes
+    cache.play(str(audio_file))
+    assert str(audio_file) in cache.cache
+
+
+def test_sound_cacher_returns_none_when_no_output(monkeypatch, tmp_path):
+    monkeypatch.setattr(sound_cacher, "o", None)
+    cache = SoundCacher()
+    assert cache.play(str(tmp_path / "missing.ogg")) is None

--- a/client/tests/test_sound_manager.py
+++ b/client/tests/test_sound_manager.py
@@ -1,0 +1,168 @@
+import pytest
+
+import sound_manager as sm_mod
+from sound_manager import SoundManager
+
+
+class DummySound:
+    def __init__(self):
+        self.stop_called = False
+        self.volume = 1.0
+        self.looping = False
+        self.pan = 0.0
+        self.played = False
+
+    def stop(self):
+        self.stop_called = True
+
+    def play(self):
+        self.played = True
+
+
+class FakeSoundCacher:
+    def __init__(self):
+        self.calls = []
+        self.refs = []
+        self.cache = {}
+
+    def play(self, path, pan=0.0, volume=1.0, pitch=1.0):
+        sound = DummySound()
+        sound.pan = pan
+        sound.volume = volume
+        sound.pitch = pitch
+        self.calls.append((path, pan, volume, pitch))
+        return sound
+
+
+def make_manager(tmp_path):
+    manager = SoundManager()
+    manager.sound_cacher = FakeSoundCacher()
+    manager.sounds_folder = str(tmp_path)
+    return manager
+
+
+def test_play_passes_full_path(tmp_path):
+    (tmp_path / "click.ogg").write_bytes(b"123")
+    manager = make_manager(tmp_path)
+    stream = manager.play("click.ogg", volume=0.4, pan=0.1, pitch=1.1)
+
+    assert isinstance(stream, DummySound)
+    path, pan, volume, pitch = manager.sound_cacher.calls[0]
+    assert path.endswith("click.ogg")
+    assert pan == 0.1
+    assert volume == 0.4
+    assert pitch == 1.1
+
+
+def test_music_stops_previous_track(tmp_path):
+    (tmp_path / "intro.ogg").write_bytes(b"1")
+    (tmp_path / "loop.ogg").write_bytes(b"2")
+    manager = make_manager(tmp_path)
+
+    manager.music("intro.ogg")
+    first_stream = manager.current_music
+    manager.music("loop.ogg")
+
+    assert first_stream.stop_called is True
+    assert manager.current_music_name == "loop.ogg"
+
+
+def test_stop_music_without_fade(tmp_path):
+    manager = make_manager(tmp_path)
+    manager.current_music = DummySound()
+    manager.current_music_name = "playing.ogg"
+
+    manager.stop_music(fade=False)
+    assert manager.current_music is None
+    assert manager.current_music_name is None
+    assert manager.sound_cacher.calls == []
+
+
+def test_set_music_volume_updates_current_stream(tmp_path):
+    manager = make_manager(tmp_path)
+    manager.current_music = DummySound()
+    manager.set_music_volume(0.75)
+    assert pytest.approx(manager.current_music.volume, rel=0.0) == 0.75
+
+
+def test_menu_sounds_use_configured_names(tmp_path):
+    manager = make_manager(tmp_path)
+    manager.set_menuclick_sound("click.ogg")
+    manager.set_menuenter_sound("enter.ogg")
+    manager.play_menuclick()
+    manager.play_menuenter()
+    played = [call[0].split("/")[-1] for call in manager.sound_cacher.calls]
+    assert played == ["click.ogg", "enter.ogg"]
+
+
+def test_add_and_remove_playlist(monkeypatch, tmp_path):
+    created = {}
+
+    class DummyPlaylist:
+        def __init__(self, tracks, audio_type, sound_manager, shuffle, repeats, auto_start, auto_remove):
+            self.tracks = list(tracks)
+            self.audio_type = audio_type
+            self.sound_manager = sound_manager
+            self.stop_called = False
+            created["playlist"] = self
+
+        def stop(self):
+            self.stop_called = True
+
+    monkeypatch.setattr(sm_mod, "AudioPlaylist", DummyPlaylist)
+    manager = make_manager(tmp_path)
+    manager.add_playlist("bgm", ["track.ogg"], audio_type="music", auto_start=False)
+
+    assert "bgm" in manager.playlists
+    playlist = manager.playlists["bgm"]
+    assert playlist.tracks == ["track.ogg"]
+
+    manager.remove_playlist("bgm")
+    assert playlist.stop_called is True
+    assert "bgm" not in manager.playlists
+
+
+def test_play_returns_none_when_sound_cacher_fails(tmp_path):
+    manager = make_manager(tmp_path)
+
+    def boom(*_args, **_kwargs):
+        raise FileNotFoundError
+
+    manager.sound_cacher.play = boom  # type: ignore[assignment]
+    assert manager.play("missing.ogg") is None
+
+
+def test_music_handles_exception_and_resets_state(tmp_path):
+    manager = make_manager(tmp_path)
+    old_music = DummySound()
+    manager.current_music = old_music
+    manager.current_music_name = "old.ogg"
+
+    def boom(*_args, **_kwargs):
+        raise IOError("bad audio")
+
+    manager.sound_cacher.play = boom  # type: ignore[assignment]
+    manager.music("new.ogg")
+
+    assert old_music.stop_called is True
+    assert manager.current_music is None
+    assert manager.current_music_name is None
+
+
+def test_music_skips_restart_when_same_track(tmp_path):
+    manager = make_manager(tmp_path)
+    existing = DummySound()
+    manager.current_music = existing
+    manager.current_music_name = "loop.ogg"
+
+    called = []
+
+    def fake_play(*_args, **_kwargs):
+        called.append(1)
+        return DummySound()
+
+    manager.sound_cacher.play = fake_play  # type: ignore[assignment]
+    manager.music("loop.ogg")
+
+    assert called == []
+    assert manager.current_music is existing

--- a/client/tests/test_ui_dialogs.py
+++ b/client/tests/test_ui_dialogs.py
@@ -1,0 +1,163 @@
+from dataclasses import dataclass
+
+import pytest
+import wx
+
+from ui.login_dialog import LoginDialog
+from ui.server_manager import AccountEditorDialog
+
+
+class StubConfigManager:
+    def __init__(self):
+        self.servers = {
+            "srv-1": {
+                "name": "Localhost",
+                "accounts": {
+                    "acct-1": {
+                        "username": "alice",
+                        "password": "secret",
+                        "email": "alice@example.com",
+                        "notes": "admin",
+                    }
+                },
+            },
+            "srv-2": {"name": "Production", "accounts": {}},
+        }
+        self.last_server = "srv-1"
+        self.last_account = "acct-1"
+        self.add_calls = []
+        self.update_calls = []
+
+    def get_all_servers(self):
+        return self.servers
+
+    def get_server_accounts(self, server_id):
+        return self.servers[server_id]["accounts"]
+
+    def get_last_server_id(self):
+        return self.last_server
+
+    def get_last_account_id(self, server_id):
+        return self.last_account if server_id == self.last_server else None
+
+    def add_account(self, server_id, username, password, email="", notes=""):
+        self.add_calls.append(
+            (server_id, {"username": username, "password": password, "email": email, "notes": notes})
+        )
+        return "acct-new"
+
+    def update_account(self, server_id, account_id, **kwargs):
+        self.update_calls.append((server_id, account_id, kwargs))
+
+    def get_account_by_id(self, server_id, account_id):
+        return self.servers[server_id]["accounts"].get(account_id)
+
+
+@pytest.fixture
+def messagebox_spy(monkeypatch):
+    calls = []
+
+    def fake_messagebox(message, caption, style):
+        calls.append({"message": message, "caption": caption, "style": style})
+        return wx.ID_OK
+
+    monkeypatch.setattr(wx, "MessageBox", fake_messagebox)
+    return calls
+
+
+def test_login_dialog_populates_servers(wx_app, monkeypatch):
+    stub = StubConfigManager()
+    monkeypatch.setattr("ui.login_dialog.ConfigManager", lambda: stub)
+
+    dlg = LoginDialog(None)
+    try:
+        assert dlg.server_combo.GetCount() == len(stub.servers)
+        assert dlg.accounts_list.GetCount() == len(
+            stub.servers[stub.last_server]["accounts"]
+        )
+        # selecting server without accounts should clear list
+        dlg.server_combo.SetSelection(1)
+        dlg.on_server_change(wx.CommandEvent())
+        assert dlg.accounts_list.GetCount() == 0
+    finally:
+        dlg.Destroy()
+
+
+def test_account_editor_dialog_creates_account(wx_app):
+    stub = StubConfigManager()
+    dlg = AccountEditorDialog(None, stub, "srv-1")
+    try:
+        dlg.username_input.SetValue("newuser")
+        dlg.password_input.SetValue("p@ss")
+        dlg.email_input.SetValue("new@example.com")
+        dlg.notes_input.SetValue("note")
+
+        assert dlg._save_if_needed()
+        assert stub.add_calls
+
+        # Toggle password visibility
+        dlg.on_show_password(wx.CommandEvent())
+        assert dlg.password_plain.IsShown()
+    finally:
+        dlg.Destroy()
+
+
+def test_account_editor_dialog_updates_existing_account(wx_app):
+    stub = StubConfigManager()
+    dlg = AccountEditorDialog(None, stub, "srv-1", "acct-1")
+    try:
+        dlg.username_input.SetValue("alice-new")
+        dlg.password_input.SetValue("new-secret")
+        dlg.email_input.SetValue("alice+demo@example.com")
+        dlg.notes_input.SetValue("updated")
+
+        assert dlg._save_if_needed()
+        assert stub.update_calls[-1] == (
+            "srv-1",
+            "acct-1",
+            {
+                "username": "alice-new",
+                "password": "new-secret",
+                "email": "alice+demo@example.com",
+                "notes": "updated",
+            },
+        )
+    finally:
+        dlg.Destroy()
+
+
+def test_account_editor_validation_requires_username(wx_app, messagebox_spy):
+    stub = StubConfigManager()
+    dlg = AccountEditorDialog(None, stub, "srv-1")
+    try:
+        dlg.username_input.SetValue("")
+        dlg.password_input.SetValue("pass")
+        assert dlg._validate_for_close() is False
+        assert messagebox_spy[-1]["message"] == "Username cannot be empty."
+    finally:
+        dlg.Destroy()
+
+
+def test_account_editor_validation_requires_password(wx_app, messagebox_spy):
+    stub = StubConfigManager()
+    dlg = AccountEditorDialog(None, stub, "srv-1")
+    try:
+        dlg.username_input.SetValue("bob")
+        dlg.password_input.SetValue("")
+        assert dlg._validate_for_close() is False
+        assert messagebox_spy[-1]["message"] == "Password cannot be empty."
+    finally:
+        dlg.Destroy()
+
+
+def test_account_editor_validation_rejects_invalid_email(wx_app, messagebox_spy):
+    stub = StubConfigManager()
+    dlg = AccountEditorDialog(None, stub, "srv-1")
+    try:
+        dlg.username_input.SetValue("carol")
+        dlg.password_input.SetValue("pass")
+        dlg.email_input.SetValue("bad-email@@example.com")
+        assert dlg._validate_for_close() is False
+        assert messagebox_spy[-1]["message"] == "Invalid email address format."
+    finally:
+        dlg.Destroy()

--- a/client/ui/main_window.py
+++ b/client/ui/main_window.py
@@ -64,6 +64,11 @@ class MainWindow(wx.Frame):
         self.server_id = self.credentials.get("server_id")
         self.config_manager = self.credentials.get("config_manager")
 
+        # Attributes mocked in headless tests (avoid accessing real widgets before they exist)
+        self.menu_list = None
+        self.chat_input = None
+        self.history_text = None
+
         # Initialize TTS speaker
         self.speaker = auto_output.Auto()
 


### PR DESCRIPTION
## Summary
- add headless-friendly pytest suites covering menu packets, network manager flows, dialogs, config migrations, sound, and buffer logic
- tweak MainWindow to initialize placeholder widgets for headless instantiation used by the new tests
- provide wx fixtures that auto-skip when no display is available

Fixes #113.

## Testing
- TMPDIR=/podman/tmp PYTHONPATH=/podman/tmp/pydeps nix --extra-experimental-features "nix-command flakes" develop . --command bash -lc "cd client && python -m pytest"
