### PR TITLE
Clear input boxes when typing

### DIFF
--- a/client/tests/test_main_window_edit.py
+++ b/client/tests/test_main_window_edit.py
@@ -1,0 +1,138 @@
+import types
+
+import pytest
+
+from ui import main_window as main_mod
+
+
+class DummyWidget:
+    def __init__(self):
+        self.visible = True
+        self.label = ""
+        self.focused = False
+        self.enabled = True
+        self.selection = None
+        self.value = ""
+
+    def Hide(self):
+        self.visible = False
+
+    def Show(self):
+        self.visible = True
+
+    def SetLabel(self, text):  # noqa: N802
+        self.label = text
+
+    def SetFocus(self):  # noqa: N802
+        self.focused = True
+
+    def IsEnabled(self):  # noqa: N802
+        return self.enabled
+
+    def SetValue(self, value):  # noqa: N802
+        self.value = value
+
+    def GetValue(self):  # noqa: N802
+        return self.value
+
+    def Clear(self):
+        self.value = ""
+
+    def SetEditable(self, _editable):  # noqa: N802
+        pass
+
+    def GetLastPosition(self):  # noqa: N802
+        return len(self.value)
+
+    def SetSelection(self, start, end):  # noqa: N802
+        self.selection = (start, end)
+
+
+class DummyKeyEvent:
+    def __init__(self, key_code, *, shift=False, control=False, alt=False, meta=False):
+        self._key_code = key_code
+        self._shift = shift
+        self._control = control
+        self._alt = alt
+        self._meta = meta
+        self.skipped = False
+
+    def GetKeyCode(self):  # noqa: N802
+        return self._key_code
+
+    def ShiftDown(self):  # noqa: N802
+        return self._shift
+
+    def ControlDown(self):  # noqa: N802
+        return self._control
+
+    def AltDown(self):  # noqa: N802
+        return self._alt
+
+    def MetaDown(self):  # noqa: N802
+        return self._meta
+
+    def Skip(self):
+        self.skipped = True
+
+
+def make_minimal_window(monkeypatch):
+    window = main_mod.MainWindow.__new__(main_mod.MainWindow)
+    window.menu_list = DummyWidget()
+    window.menu_label = DummyWidget()
+    window.edit_label = DummyWidget()
+    window.edit_input = DummyWidget()
+    window.edit_input_multiline = DummyWidget()
+    window.sound_manager = types.SimpleNamespace(play=lambda *args, **kwargs: None)
+    window.client_options = {}
+    window.current_mode = "list"
+    window.edit_mode_callback = None
+    window.current_edit_read_only = False
+    window.current_edit_multiline = False
+    window._pending_edit_clear = False
+    window._pending_multiline_clear = False
+    window.menu_list.Hide()
+    window.menu_label.Hide()
+    window.edit_input.Hide()
+    window.edit_input_multiline.Hide()
+    window.edit_label.Hide()
+
+    def immediate_call_after(func, ctrl):
+        func(ctrl)
+
+    monkeypatch.setattr(main_mod.wx, "CallAfter", immediate_call_after)
+    return window
+
+
+def test_switch_to_edit_mode_selects_default_value(monkeypatch):
+    window = make_minimal_window(monkeypatch)
+
+    window.switch_to_edit_mode(prompt="Max score", default_value="500", multiline=False, read_only=False)
+
+    assert window.edit_input.selection == (0, 3)
+    assert window._pending_edit_clear is True
+    assert window._pending_multiline_clear is False
+
+
+def test_on_edit_char_clears_pending_text(monkeypatch):
+    window = make_minimal_window(monkeypatch)
+    window.switch_to_edit_mode(prompt="Score", default_value="500", multiline=False, read_only=False)
+
+    event = DummyKeyEvent(ord("1"))
+    window.on_edit_char(event)
+
+    assert window.edit_input.GetValue() == ""
+    assert window._pending_edit_clear is False
+    assert event.skipped is True
+
+
+def test_on_edit_multiline_char_clears_pending_text(monkeypatch):
+    window = make_minimal_window(monkeypatch)
+    window.switch_to_edit_mode(prompt="Notes", default_value="Hello", multiline=True, read_only=False)
+
+    event = DummyKeyEvent(ord("A"))
+    window.on_edit_multiline_char(event)
+
+    assert window.edit_input_multiline.GetValue() == ""
+    assert window._pending_multiline_clear is False
+    assert event.skipped is True

--- a/client/ui/main_window.py
+++ b/client/ui/main_window.py
@@ -44,6 +44,25 @@ class UiPlatformConfig:
 class MainWindow(wx.Frame):
     """Main application window for Play Palace v9 client."""
 
+    _NAVIGATION_KEYS = {
+        wx.WXK_LEFT,
+        wx.WXK_RIGHT,
+        wx.WXK_UP,
+        wx.WXK_DOWN,
+        wx.WXK_NUMPAD_LEFT,
+        wx.WXK_NUMPAD_RIGHT,
+        wx.WXK_NUMPAD_UP,
+        wx.WXK_NUMPAD_DOWN,
+        wx.WXK_HOME,
+        wx.WXK_END,
+        wx.WXK_NUMPAD_HOME,
+        wx.WXK_NUMPAD_END,
+        wx.WXK_PAGEUP,
+        wx.WXK_PAGEDOWN,
+        wx.WXK_NUMPAD_PAGEUP,
+        wx.WXK_NUMPAD_PAGEDOWN,
+    }
+
     def __init__(self, credentials=None):
         """
         Initialize the main window.
@@ -113,6 +132,8 @@ class MainWindow(wx.Frame):
         self.current_menu_item_ids = []  # Track item IDs for current menu (parallel to menu items)
         self.current_edit_multiline = False  # Track if current editbox is multiline
         self.current_edit_read_only = False  # Track if current editbox is read-only
+        self._pending_edit_clear = False  # Clear single-line value on first printable key
+        self._pending_multiline_clear = False  # Clear multiline value on first printable key
 
         # Ping tracking
         self._ping_start_time = None  # Track when ping was sent
@@ -919,6 +940,7 @@ class MainWindow(wx.Frame):
             self.edit_input_multiline.SetEditable(not read_only)
             self.edit_input_multiline.SetFocus()
             self.current_edit_multiline = True
+            self._schedule_pending_clear(self.edit_input_multiline, True, default_value, read_only)
         else:
             self.edit_input_multiline.Hide()
             self.edit_input.Show()
@@ -927,6 +949,7 @@ class MainWindow(wx.Frame):
             self.edit_input.SetEditable(not read_only)
             self.edit_input.SetFocus()
             self.current_edit_multiline = False
+            self._schedule_pending_clear(self.edit_input, False, default_value, read_only)
 
         self.edit_label.Show()
 
@@ -953,6 +976,8 @@ class MainWindow(wx.Frame):
 
         self.current_mode = "list"
         self.edit_mode_callback = None
+        self._pending_edit_clear = False
+        self._pending_multiline_clear = False
 
     def on_edit_enter(self, event):
         """Handle Enter key in edit mode input."""
@@ -982,6 +1007,19 @@ class MainWindow(wx.Frame):
             self.switch_to_list_mode()
             return  # Don't process the Escape key
 
+        if key_code in self._NAVIGATION_KEYS or event.ShiftDown() or event.ControlDown() or event.AltDown() or event.MetaDown():
+            self._pending_edit_clear = False
+            event.Skip()
+            return
+
+        if (
+            self._pending_edit_clear
+            and self._should_clear_on_char_event(event, key_code)
+            and not self.current_edit_read_only
+        ):
+            self.edit_input.Clear()
+            self._pending_edit_clear = False
+
         # Only play typing sounds for printable characters (not Enter, Backspace, etc.)
         # Don't play if read-only or if user has disabled typing sounds
         if 32 <= key_code <= 126:  # Printable ASCII range
@@ -1009,6 +1047,19 @@ class MainWindow(wx.Frame):
                 self.edit_mode_callback("")
             self.switch_to_list_mode()
             return  # Don't process the Escape key
+
+        if key_code in self._NAVIGATION_KEYS or event.ShiftDown() or event.ControlDown() or event.AltDown() or event.MetaDown():
+            self._pending_multiline_clear = False
+            event.Skip()
+            return
+
+        if (
+            self._pending_multiline_clear
+            and self._should_clear_on_char_event(event, key_code)
+            and not self.current_edit_read_only
+        ):
+            self.edit_input_multiline.Clear()
+            self._pending_multiline_clear = False
 
         # Check for Enter key
         if key_code == wx.WXK_RETURN:
@@ -1058,6 +1109,33 @@ class MainWindow(wx.Frame):
 
         # Allow all other keys (including plain Enter for newlines in editable mode)
         event.Skip()
+
+    def _schedule_pending_clear(self, ctrl, multiline: bool, default_value: str, read_only: bool) -> None:
+        should_select = bool(default_value) and not read_only and ctrl.IsEnabled()
+        if multiline:
+            self._pending_edit_clear = False
+            self._pending_multiline_clear = should_select
+        else:
+            self._pending_multiline_clear = False
+            self._pending_edit_clear = should_select
+
+        if should_select:
+            wx.CallAfter(self._select_all_text, ctrl)
+
+    @staticmethod
+    def _select_all_text(ctrl) -> None:
+        if not ctrl:
+            return
+        length = ctrl.GetLastPosition()
+        ctrl.SetSelection(0, length)
+
+    @staticmethod
+    def _should_clear_on_char_event(event, key_code: int) -> bool:
+        if not (32 <= key_code <= 126):
+            return False
+        if event.ControlDown() or event.AltDown() or event.MetaDown():
+            return False
+        return True
 
     # Sound and music methods (for server calls via CallAfter)
 


### PR DESCRIPTION
## Summary
- select existing edit dialog values so first printable key replaces instead of appending
- gate both single-line and multiline controls with pending-clear flags
- add regression tests that emulate the edit dialog widgets to cover the behavior

## Testing
- PlayPalace Development Environment (flakes)
=========================================
Python: Python 3.11.10
uv: uv 0.1.45

Common commands:
  nix develop . --command bash
  ./run_server.sh
  ./run_client.sh *(fails: building wxpython wheel exhausts disk space)

@jage9 Could you pull this branch and confirm the Farkle option dialog behaves as expected on your machine?