### PR TITLE
Add server_status packet to typed schema

### DIFF
--- a/client/packet_schema.json
+++ b/client/packet_schema.json
@@ -1342,6 +1342,61 @@
         "title": "RequestInputPacket",
         "type": "object"
       },
+      "ServerStatusPacket": {
+        "additionalProperties": false,
+        "properties": {
+          "message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Message"
+          },
+          "mode": {
+            "enum": [
+              "initializing",
+              "maintenance",
+              "running"
+            ],
+            "title": "Mode",
+            "type": "string"
+          },
+          "resume_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Resume At"
+          },
+          "retry_after": {
+            "minimum": 1,
+            "title": "Retry After",
+            "type": "integer"
+          },
+          "type": {
+            "const": "server_status",
+            "default": "server_status",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "mode",
+          "retry_after"
+        ],
+        "title": "ServerStatusPacket",
+        "type": "object"
+      },
       "SpeakPacket": {
         "additionalProperties": false,
         "properties": {
@@ -1513,6 +1568,7 @@
         "pong": "#/$defs/PongPacket",
         "remove_playlist": "#/$defs/RemovePlaylistPacket",
         "request_input": "#/$defs/RequestInputPacket",
+        "server_status": "#/$defs/ServerStatusPacket",
         "speak": "#/$defs/SpeakPacket",
         "start_playlist": "#/$defs/StartPlaylistPacket",
         "stop_ambience": "#/$defs/StopAmbiencePacket",
@@ -1555,6 +1611,9 @@
       },
       {
         "$ref": "#/$defs/DisconnectPacket"
+      },
+      {
+        "$ref": "#/$defs/ServerStatusPacket"
       },
       {
         "$ref": "#/$defs/TableCreatePacket"

--- a/server/network/packet_models.py
+++ b/server/network/packet_models.py
@@ -262,6 +262,14 @@ class DisconnectPacket(BasePacket):
     return_to_login: bool = False
 
 
+class ServerStatusPacket(BasePacket):
+    type: Literal["server_status"] = "server_status"
+    mode: Literal["initializing", "maintenance", "running"]
+    retry_after: Annotated[int, Field(ge=1)]
+    message: str | None = None
+    resume_at: str | None = None
+
+
 class TableCreatePacket(BasePacket):
     type: Literal["table_create"] = "table_create"
     host: str
@@ -356,6 +364,7 @@ ServerToClientPacket = Annotated[
         RequestInputPacket,
         ClearUIPacket,
         DisconnectPacket,
+        ServerStatusPacket,
         TableCreatePacket,
         UpdateOptionsListsPacket,
         PongPacket,

--- a/server/packet_schema.json
+++ b/server/packet_schema.json
@@ -1342,6 +1342,61 @@
         "title": "RequestInputPacket",
         "type": "object"
       },
+      "ServerStatusPacket": {
+        "additionalProperties": false,
+        "properties": {
+          "message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Message"
+          },
+          "mode": {
+            "enum": [
+              "initializing",
+              "maintenance",
+              "running"
+            ],
+            "title": "Mode",
+            "type": "string"
+          },
+          "resume_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Resume At"
+          },
+          "retry_after": {
+            "minimum": 1,
+            "title": "Retry After",
+            "type": "integer"
+          },
+          "type": {
+            "const": "server_status",
+            "default": "server_status",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "mode",
+          "retry_after"
+        ],
+        "title": "ServerStatusPacket",
+        "type": "object"
+      },
       "SpeakPacket": {
         "additionalProperties": false,
         "properties": {
@@ -1513,6 +1568,7 @@
         "pong": "#/$defs/PongPacket",
         "remove_playlist": "#/$defs/RemovePlaylistPacket",
         "request_input": "#/$defs/RequestInputPacket",
+        "server_status": "#/$defs/ServerStatusPacket",
         "speak": "#/$defs/SpeakPacket",
         "start_playlist": "#/$defs/StartPlaylistPacket",
         "stop_ambience": "#/$defs/StopAmbiencePacket",
@@ -1555,6 +1611,9 @@
       },
       {
         "$ref": "#/$defs/DisconnectPacket"
+      },
+      {
+        "$ref": "#/$defs/ServerStatusPacket"
       },
       {
         "$ref": "#/$defs/TableCreatePacket"

--- a/server/tests/test_packet_schemas.py
+++ b/server/tests/test_packet_schemas.py
@@ -64,6 +64,13 @@ SERVER_TO_CLIENT_SAMPLES = [
         "show_message": True,
         "return_to_login": True,
     },
+    {
+        "type": "server_status",
+        "mode": "maintenance",
+        "retry_after": 30,
+        "message": "Applying updates",
+        "resume_at": "2026-02-07T18:00:00Z",
+    },
     {"type": "table_create", "host": "Alice", "game": "Poker"},
     {"type": "update_options_lists", "games": [{"type": "poker", "name": "Poker"}]},
     {"type": "pong"},


### PR DESCRIPTION
Summary:
- add a typed ServerStatusPacket model to the authoritative packet schema
- include server_status in the ServerToClientPacket discriminated union
- regenerate server/packet_schema.json and client/packet_schema.json
- add a server-to-client round-trip sample for server_status in packet schema tests

Testing:
- scripts/nix_server_pytest.sh
- result: 623 passed, 32 skipped