### PR TITLE
Improve disconnect messaging

### DIFF
--- a/client/packet_schema.json
+++ b/client/packet_schema.json
@@ -826,10 +826,35 @@
       "DisconnectPacket": {
         "additionalProperties": false,
         "properties": {
+          "message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Message"
+          },
           "reconnect": {
             "default": false,
             "title": "Reconnect",
             "type": "boolean"
+          },
+          "retry_after": {
+            "anyOf": [
+              {
+                "minimum": 1,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Retry After"
           },
           "return_to_login": {
             "default": false,
@@ -840,6 +865,23 @@
             "default": false,
             "title": "Show Message",
             "type": "boolean"
+          },
+          "status_mode": {
+            "anyOf": [
+              {
+                "enum": [
+                  "initializing",
+                  "maintenance",
+                  "running"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Status Mode"
           },
           "type": {
             "const": "disconnect",

--- a/client/tests/test_main_window_startup.py
+++ b/client/tests/test_main_window_startup.py
@@ -164,6 +164,27 @@ def test_on_server_disconnect_status_mode(monkeypatch):
     assert reconnect_calls[0][0] == 10000
 
 
+def test_on_server_disconnect_uses_packet_message(monkeypatch):
+    window = make_window_stub(monkeypatch, should_connect=True)
+    window.connected = False
+    window.speaker = types.SimpleNamespace(speak=lambda *args, **kwargs: None)
+
+    window.on_server_disconnect({"show_message": True, "message": "Please contact support."})
+
+    assert window._show_connection_error_calls[-1] == "Please contact support."
+
+
+def test_on_server_disconnect_falls_back_to_last_server_message(monkeypatch):
+    window = make_window_stub(monkeypatch, should_connect=True)
+    window.connected = False
+    window.speaker = types.SimpleNamespace(speak=lambda *args, **kwargs: None)
+    window.last_server_message = "Account banned."
+
+    window.on_server_disconnect({"show_message": True})
+
+    assert window._show_connection_error_calls[-1] == "Account banned."
+
+
 def test_do_reconnect_resets_after_max_attempts(monkeypatch):
     window = make_window_stub(monkeypatch, should_connect=False)
     window.speaker = types.SimpleNamespace(speak=lambda *args, **kwargs: None)

--- a/client/ui/main_window.py
+++ b/client/ui/main_window.py
@@ -1231,9 +1231,12 @@ class MainWindow(wx.Frame):
         return_to_login = packet.get("return_to_login", False)
         status_mode = packet.get("status_mode")
         retry_after = packet.get("retry_after")
+        disconnect_message = packet.get("message")
 
         if status_mode:
-            message = self._format_status_text(self.last_server_status_packet or {})
+            message = disconnect_message or self._format_status_text(
+                self.last_server_status_packet or {}
+            )
             self._show_connection_error(message, return_to_login=True)
             if retry_after:
                 delay = max(1, int(retry_after))
@@ -1251,7 +1254,8 @@ class MainWindow(wx.Frame):
             )
         elif show_message:
             # Explicit disconnect with message dialog (e.g., account declined)
-            self._show_connection_error("Disconnected by server.", return_to_login=return_to_login)
+            message = disconnect_message or self.last_server_message or "Disconnected by server."
+            self._show_connection_error(message, return_to_login=return_to_login)
         else:
             # Explicit disconnect, close quietly (e.g., user logout)
             self.speaker.speak("Disconnected.", interrupt=False)
@@ -1362,7 +1366,7 @@ class MainWindow(wx.Frame):
 
         # Build error message, including last server message if available
         error_body = message
-        if self.last_server_message:
+        if self.last_server_message and self.last_server_message not in error_body:
             error_body += f"\n\nServer message: {self.last_server_message}"
 
         if return_to_login:

--- a/server/core/administration.py
+++ b/server/core/administration.py
@@ -866,6 +866,7 @@ class AdministrationMixin:
                     "reconnect": False,
                     "show_message": True,
                     "return_to_login": True,
+                    "message": full_message,
                 })
 
         self._show_account_approval_menu(admin)
@@ -1046,6 +1047,7 @@ class AdministrationMixin:
                 "type": "disconnect",
                 "reconnect": False,
                 "show_message": True,
+                "message": full_message,
             })
 
         self._show_ban_user_menu(admin)

--- a/server/network/packet_models.py
+++ b/server/network/packet_models.py
@@ -260,6 +260,9 @@ class DisconnectPacket(BasePacket):
     reconnect: bool = False
     show_message: bool = False
     return_to_login: bool = False
+    message: str | None = None
+    status_mode: Literal["initializing", "maintenance", "running"] | None = None
+    retry_after: Annotated[int, Field(ge=1)] | None = None
 
 
 class ServerStatusPacket(BasePacket):

--- a/server/packet_schema.json
+++ b/server/packet_schema.json
@@ -826,10 +826,35 @@
       "DisconnectPacket": {
         "additionalProperties": false,
         "properties": {
+          "message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Message"
+          },
           "reconnect": {
             "default": false,
             "title": "Reconnect",
             "type": "boolean"
+          },
+          "retry_after": {
+            "anyOf": [
+              {
+                "minimum": 1,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Retry After"
           },
           "return_to_login": {
             "default": false,
@@ -840,6 +865,23 @@
             "default": false,
             "title": "Show Message",
             "type": "boolean"
+          },
+          "status_mode": {
+            "anyOf": [
+              {
+                "enum": [
+                  "initializing",
+                  "maintenance",
+                  "running"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Status Mode"
           },
           "type": {
             "const": "disconnect",

--- a/server/tests/test_server_lifecycle.py
+++ b/server/tests/test_server_lifecycle.py
@@ -41,6 +41,7 @@ async def test_client_blocked_while_initializing(server):
     assert status_packet["mode"] == "initializing"
     assert status_packet["retry_after"] >= 1
     assert client.sent[1]["status_mode"] == "initializing"
+    assert "Warming up" in client.sent[1]["message"]
     assert client.closed is True
 
 
@@ -68,4 +69,5 @@ async def test_maintenance_mode_disconnects_clients(server):
     assert [packet["type"] for packet in client.sent] == ["server_status", "disconnect"]
     assert client.sent[0]["mode"] == "maintenance"
     assert client.sent[1]["retry_after"] >= 1
+    assert "Applying updates" in client.sent[1]["message"]
     assert client.closed is True


### PR DESCRIPTION
## Summary
- allow the server to populate DisconnectPacket with message, status_mode, and retry_after metadata so admins and lifecycle transitions can tell players why they were removed
- surface that information in the wx client (favoring the packet message, then the last server status/message) and add coverage to prevent regressions
- ensure lifecycle disconnects reuse the formatted status copy and keep the schema/tests in sync

Fixes #124

## Testing
- `cd server && .venv/bin/pytest tests/test_server_lifecycle.py`
- `cd client && uv sync` (fails to build `wxpython==4.2.4` because GTK development headers are missing in the runner image; added full log in the task notes)
