### PR TITLE
Implement uv-based hook suite

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,18 @@
-# Auto detect text files and perform LF normalization
-* text=auto
+# Normalize text files to LF while preserving Windows-specific scripts.
+* text=auto eol=lf
+
+*.sh text eol=lf
+*.py text eol=lf
+*.ps1 text eol=crlf
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ftl text eol=lf
+*.json text eol=lf
+*.toml text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+
+# Treat binaries as-is.
+*.png binary
+*.wav binary
+*.ogg binary

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,103 @@
+ci:
+  skip: []
+  autoupdate_schedule: quarterly
+
+default_language_version:
+  python: python3
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
+
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    rev: 0.9.18
+    hooks:
+      - id: uv-lock
+        name: uv lock (server)
+        files: ^server/pyproject\.toml$
+        args: [--project, server]
+      - id: uv-lock
+        name: uv lock (client)
+        files: ^client/pyproject\.toml$
+        args: [--project, client]
+
+  - repo: https://github.com/tsvikas/sync-with-uv
+    rev: v0.4.0
+    hooks:
+      - id: sync-with-uv
+
+  - repo: local
+    hooks:
+      - id: regen-packet-schema
+        name: Regenerate packet schemas (uv run)
+        entry: python scripts/hooks/regen_packet_schema.py
+        language: python
+        pass_filenames: false
+        files: ^server/network/packet_models\.py$
+      - id: uv-ruff-critical
+        name: Ruff (E9,F63,F7 via uvx)
+        entry: python scripts/hooks/run_ruff.py
+        language: python
+        types: [python]
+        pass_filenames: false
+      - id: packet-schema-sync
+        name: Packet schema parity check
+        entry: python scripts/hooks/check_packet_schema_sync.py
+        language: python
+        pass_filenames: false
+        files: ^(server/packet_schema\.json|client/packet_schema\.json)
+      - id: hadolint-containerfiles
+        name: Hadolint (Containerfiles via podman)
+        entry: python scripts/hooks/run_hadolint.py
+        language: python
+        pass_filenames: false
+        stages: [manual, pre-push]
+      - id: bandit-security
+        name: Bandit security scan (manual)
+        entry: python scripts/hooks/run_bandit.py
+        language: python
+        pass_filenames: false
+        stages: [manual, pre-push]
+      - id: xenon-complexity
+        name: Xenon complexity budget (manual)
+        entry: python scripts/hooks/run_xenon.py
+        language: python
+        pass_filenames: false
+        stages: [manual, pre-push]
+      - id: vulture-deadcode
+        name: Vulture dead code scan (manual)
+        entry: python scripts/hooks/run_vulture.py
+        language: python
+        pass_filenames: false
+        stages: [manual, pre-push]
+      - id: trivy-vulnerability-scan
+        name: Trivy fs scan (manual)
+        entry: python scripts/hooks/run_trivy_vuln.py
+        language: python
+        pass_filenames: false
+        stages: [manual, pre-push]
+      - id: trivy-sbom
+        name: Trivy SBOM (manual)
+        entry: python scripts/hooks/run_trivy_sbom.py
+        language: python
+        pass_filenames: false
+        stages: [manual, pre-push]
+      - id: podman-smoke-server
+        name: Podman server image smoke test
+        entry: python scripts/hooks/podman_smoke_server.py
+        language: python
+        pass_filenames: false
+        stages: [manual, pre-push]
+      - id: podman-smoke-client
+        name: Podman client image smoke test
+        entry: python scripts/hooks/podman_smoke_client.py
+        language: python
+        pass_filenames: false
+        stages: [manual, pre-push]

--- a/docs/dev_hooks.md
+++ b/docs/dev_hooks.md
@@ -1,0 +1,40 @@
+# Developer hook workflow
+
+These notes cover how to enable the shared git hooks on Windows, WSL, and Linux.
+
+## Prerequisites
+- Python 3.11+ (already required by the repo)
+- [`uv`](https://astral.sh/uv) available on `PATH`
+- [`pre-commit`](https://pre-commit.com); install it into the uv tool space via `uv tool install pre-commit`
+
+## One-time setup
+1. From the repo root run `uv tool run pre-commit install --install-hooks`.
+2. (Optional) Run `uv tool run pre-commit run --all-files` to warm caches.
+3. On Windows/WSL, ensure the hook scripts remain executable:
+   - WSL/git-bash automatically honors the `chmod +x` bits.
+   - If you clone via Windows-native Git, run `git update-index --chmod=+x scripts/hooks/*.py` once or rerun `pre-commit install` from WSL.
+
+## What runs on each commit?
+- **General hygiene:** `check-added-large-files`, `check-merge-conflict`, `detect-private-key`, `end-of-file-fixer`, `trailing-whitespace` (markdown-aware).
+- **Dependency safety:** `uv-lock` re-locks `server/uv.lock` or `client/uv.lock` when the corresponding `pyproject.toml` changes. `sync-with-uv` keeps tool versions in `.pre-commit-config.yaml` synchronized with the `uv.lock` entries.
+- **Source checks:**
+  - `scripts/hooks/regen_packet_schema.py` reruns `uv run python tools/export_packet_schema.py` any time `server/network/packet_models.py` changes, so generated JSON stays fresh.
+  - `scripts/hooks/run_ruff.py` runs `uv tool run ruff check` over `server/` and `client/` with only the fatal rule set (`E9`, `F63`, `F7`). This catches syntax errors, undefined names, and stray break/continue issues without blocking stylistic cleanups.
+  - `scripts/hooks/check_packet_schema_sync.py` fails if `server/packet_schema.json` and `client/packet_schema.json` drift even after regeneration.
+
+## Tips for different environments
+- **Windows-only devs:** set `core.autocrlf true` (default) and leave `.gitattributes` as checked in; LF endings are enforced for Python/JSON/TOML while `.bat`/`.ps1` stay CRLF.
+- **WSL devs editing via Windows IDEs:** run `git config core.autocrlf input` inside WSL to avoid back-and-forth conversions, and rely on `.gitattributes` to normalize on commit.
+- **Linux/macOS devs:** nothing special beyond having `uv` on PATH. Hooks work inside plain bash/zsh.
+
+## Manual execution
+- Run every hook (default stage): `uv tool run pre-commit run --all-files`.
+- Run all manual/pre-push hooks (Bandit, Xenon, Vulture, Trivy, hadolint, Podman smoke tests): `uv tool run pre-commit run --hook-stage manual --all-files`.
+- Run one hook by name, e.g. `uv tool run pre-commit run hadolint-containerfiles` or `uv tool run pre-commit run bandit-security`.
+- Update hook versions quarterly (matching `ci.autoupdate_schedule`): `uv tool run pre-commit autoupdate && uv tool run pre-commit run --all-files`.
+
+## Manual/pre-push hooks available now
+- **Security/compliance:** `bandit-security`, `trivy-vulnerability-scan`, `trivy-sbom`.
+- **Code quality:** `xenon-complexity`, `vulture-deadcode`.
+- **Containers:** `hadolint-containerfiles`, `podman-smoke-server`, `podman-smoke-client` (both rebuild the shared base and component image via Podman).
+- All of the above are optional locally but wired into the config so CI can invoke them with `uv tool run pre-commit run --hook-stage manual --all-files`.

--- a/docs/nix_vs_container.md
+++ b/docs/nix_vs_container.md
@@ -1,0 +1,33 @@
+# Nix vs. Containerfile workflows
+
+PlayPalace already ships `flake.nix`, `shell.nix`, and multiple Containerfiles. This note captures when to reach for each approach and how their tooling overlaps.
+
+## When Nix shines
+- **Single-source dependency lock:** the flake captures Python, system libs, and tooling (uv, pre-commit, etc.) so contributors on Linux, macOS, or WSL get the same versions without rebuilding images.
+- **Fast iteration:** `nix develop` enters the environment instantly after the first build, which suits frequent test runs or hook development.
+- **Composable CI:** Nix derivations already power `scripts/nix_server_pytest.sh`; CI jobs can reuse the same derivation to guarantee parity with local dev.
+
+## When a Containerfile is preferable
+- **Deployment parity:** images (built via `podman build`, then run with `podman run`) mirror production packaging, so server binaries, OS hardening, and runtime flags match what gets deployed.
+- **Multi-platform distribution:** containers can be pushed to registries for QA or player-hosted servers without requiring Nix.
+- **Toolchain isolation:** images decouple from host package managers, which helps Windows hosts running PlayPalace via WSL or bare metal.
+
+## Containerfiles in this repo
+- `containers/base/Containerfile` defines the uv-enabled base image shared by every other image. Build it first via `podman build containers/base -t playpalace/base:latest`.
+- `server/Containerfile` builds the websocket game server. Build with `podman build -f server/Containerfile server -t playpalace/server:latest` (after the base image exists) and run via `podman run --rm -p 8000:8000 playpalace/server:latest`.
+- `client/Containerfile` bundles the wxPython desktop client for headless testing or remote GUI sessions. Build with `podman build -f client/Containerfile client -t playpalace/client:latest`. Run with X11/Wayland forwarding, e.g. `podman run --rm -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix playpalace/client:latest python client.py`.
+
+## Blended workflows
+- **Hadolint as a bridge:** use the `hadolint-containerfiles` manual hook (`uv tool run pre-commit run hadolint-containerfiles`) or directly invoke `podman run --rm --mount type=bind,source=$PWD,target=/workspace,ro docker.io/hadolint/hadolint:latest containers/base/Containerfile server/Containerfile client/Containerfile` so devs and CI lint identical Containerfiles before builds.
+- **Podman smoke hooks:** run `uv tool run pre-commit run podman-smoke-server` or `podman-smoke-client` to build the base + component image and execute a quick runtime check. CI can reuse the same hooks via `uv tool run pre-commit run --hook-stage manual --all-files`.
+- **Nix inside containers:** if desired, the Containerfile can call `nix develop` to produce artifacts that are then copied into the image, keeping single-source dependency logic while still shipping containerized images.
+
+## Choosing between them
+| Scenario | Prefer Nix | Prefer Containerfile |
+| --- | --- | --- |
+| Editing Python/game logic daily | ✅ fastest with `nix develop` | ❌ unnecessary rebuilds |
+| Validating production packaging | ⚠️ requires extra scripts | ✅ `podman build` tests exact image |
+| Third-party distribution | ⚠️ users need Nix tooling | ✅ ship container or tarball |
+| Hook/CI tooling | ✅ `scripts/nix_*.sh` already wrap it | ✅ reuse manual hooks via `podman` + hadolint |
+
+In short: keep day-to-day dev flows inside Nix shells, then rely on Containerfile + podman (linted by hadolint) when verifying deployable artifacts or publishing images. Both paths share the same uv/pre-commit hooks, so guardrails remain consistent regardless of the environment.

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,7 @@
+line-length = 100
+src = ["server", "client"]
+target-version = "py311"
+
+[lint]
+select = ["E9", "F63", "F7"]
+fixable = []

--- a/scripts/hooks/check_packet_schema_sync.py
+++ b/scripts/hooks/check_packet_schema_sync.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Ensure the generated packet schemas stay byte-identical across server/client."""
+from __future__ import annotations
+
+import hashlib
+import sys
+from pathlib import Path
+
+
+SCHEMA_COMMAND = "cd server && uv run python tools/export_packet_schema.py"
+
+
+def file_digest(path: Path) -> str:
+    data = path.read_bytes()
+    return hashlib.sha256(data).hexdigest()
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    server_schema = repo_root / "server" / "packet_schema.json"
+    client_schema = repo_root / "client" / "packet_schema.json"
+
+    missing = [p for p in (server_schema, client_schema) if not p.exists()]
+    if missing:
+        print("Missing schema files:\n" + "\n".join(str(p) for p in missing))
+        print(f"Regenerate them via `{SCHEMA_COMMAND}`.")
+        return 1
+
+    if server_schema.read_bytes() != client_schema.read_bytes():
+        print("Server and client packet schemas differ.")
+        print(f"Re-run `{SCHEMA_COMMAND}` and restage the files.")
+        print(f"server hash: {file_digest(server_schema)}")
+        print(f"client hash: {file_digest(client_schema)}")
+        return 1
+
+    print("Packet schemas match.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/hooks/podman_smoke_client.py
+++ b/scripts/hooks/podman_smoke_client.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Build and smoke-test the client container image with Podman."""
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+BASE_IMAGE = "playpalace/base:latest"
+CLIENT_IMAGE = "playpalace/client:smoke"
+
+
+def run(cmd: list[str], cwd: Path | None = None) -> int:
+    print("Running:", " ".join(cmd))
+    proc = subprocess.run(cmd, cwd=cwd, check=False)
+    return proc.returncode
+
+
+def ensure_podman() -> str:
+    podman = shutil.which("podman")
+    if not podman:
+        raise SystemExit("podman is required for the smoke test.")
+    return podman
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    podman = ensure_podman()
+
+    base_build = [
+        podman,
+        "build",
+        "-f",
+        "containers/base/Containerfile",
+        "-t",
+        BASE_IMAGE,
+        ".",
+    ]
+    if run(base_build, cwd=repo_root) != 0:
+        return 1
+
+    client_build = [
+        podman,
+        "build",
+        "-f",
+        "client/Containerfile",
+        "-t",
+        CLIENT_IMAGE,
+        "client",
+    ]
+    if run(client_build, cwd=repo_root) != 0:
+        return 1
+
+    smoke_cmd = [
+        podman,
+        "run",
+        "--rm",
+        "-e",
+        "DISPLAY=",
+        CLIENT_IMAGE,
+        "python",
+        "-m",
+        "compileall",
+        "client",
+    ]
+    return run(smoke_cmd, cwd=repo_root)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/hooks/podman_smoke_server.py
+++ b/scripts/hooks/podman_smoke_server.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Build and smoke-test the server container image with Podman."""
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+BASE_IMAGE = "playpalace/base:latest"
+SERVER_IMAGE = "playpalace/server:smoke"
+
+
+def run(cmd: list[str], cwd: Path | None = None) -> int:
+    print("Running:", " ".join(cmd))
+    proc = subprocess.run(cmd, cwd=cwd, check=False)
+    return proc.returncode
+
+
+def ensure_podman() -> str:
+    podman = shutil.which("podman")
+    if not podman:
+        raise SystemExit("podman is required for the smoke test.")
+    return podman
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    podman = ensure_podman()
+
+    base_build = [
+        podman,
+        "build",
+        "-f",
+        "containers/base/Containerfile",
+        "-t",
+        BASE_IMAGE,
+        ".",
+    ]
+    if run(base_build, cwd=repo_root) != 0:
+        return 1
+
+    server_build = [
+        podman,
+        "build",
+        "-f",
+        "server/Containerfile",
+        "-t",
+        SERVER_IMAGE,
+        "server",
+    ]
+    if run(server_build, cwd=repo_root) != 0:
+        return 1
+
+    smoke_cmd = [
+        podman,
+        "run",
+        "--rm",
+        SERVER_IMAGE,
+        "python",
+        "main.py",
+        "--help",
+    ]
+    return run(smoke_cmd, cwd=repo_root)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/hooks/regen_packet_schema.py
+++ b/scripts/hooks/regen_packet_schema.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Rebuild packet schemas whenever packet models change."""
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    server_dir = repo_root / "server"
+    uv = shutil.which("uv")
+    if not uv:
+        print("uv is required to regenerate packet schemas.")
+        return 1
+
+    cmd = [uv, "run", "python", "tools/export_packet_schema.py"]
+    print("Running:", " ".join(cmd))
+    proc = subprocess.run(cmd, cwd=server_dir, check=False)
+    if proc.returncode == 0:
+        print("Packet schemas regenerated.")
+    return proc.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/hooks/run_bandit.py
+++ b/scripts/hooks/run_bandit.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Run Bandit via uv against server and client sources."""
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+EXCLUDES = [
+    "server/tests",
+    "client/tests",
+]
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    uv = shutil.which("uv")
+    if not uv:
+        print("uv is required to run Bandit.")
+        return 1
+
+    exclude_arg = ",".join(EXCLUDES)
+    cmd = [
+        uv,
+        "tool",
+        "run",
+        "bandit",
+        "-q",
+        "-r",
+        "server",
+        "client",
+        "-x",
+        exclude_arg,
+    ]
+    print("Running:", " ".join(cmd))
+    proc = subprocess.run(cmd, cwd=repo_root, check=False)
+    return proc.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/hooks/run_hadolint.py
+++ b/scripts/hooks/run_hadolint.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Run hadolint over all Containerfiles using podman."""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+CONTAINERFILES = (
+    "containers/base/Containerfile",
+    "server/Containerfile",
+    "client/Containerfile",
+)
+IMAGE = "docker.io/hadolint/hadolint:latest"
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    podman = shutil.which("podman")
+    if not podman:
+        print("podman is required for hadolint checks; install Podman and retry.")
+        return 1
+
+    targets = []
+    for relative in CONTAINERFILES:
+        path = repo_root / relative
+        if not path.exists():
+            print(f"Skipping missing Containerfile: {relative}")
+            continue
+        targets.append(relative)
+
+    if not targets:
+        print("No Containerfiles found; skipping hadolint run.")
+        return 0
+
+    mount_arg = f"type=bind,source={repo_root},target=/workspace,ro"
+    cmd = [
+        podman,
+        "run",
+        "--rm",
+        "--mount",
+        mount_arg,
+        "-w",
+        "/workspace",
+        "--entrypoint",
+        "hadolint",
+        IMAGE,
+        *targets,
+    ]
+    print("Running:", " ".join(cmd))
+    proc = subprocess.run(cmd, check=False)
+    return proc.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/hooks/run_ruff.py
+++ b/scripts/hooks/run_ruff.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Wrapper to run Ruff via uv/uvx in a cross-platform way.
+
+The script intentionally limits the linting rule set to the most critical
+runtime errors (configured in ruff.toml) so it can run quickly during
+pre-commit without forcing a full repo cleanup.
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def find_uv() -> str:
+    uv = shutil.which("uv")
+    if uv:
+        return uv
+    raise SystemExit("uv is required to run Ruff; install via https://astral.sh/uv")
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    uv = find_uv()
+    cmd = [uv, "tool", "run", "ruff", "check", "server", "client"]
+    print("Running:", " ".join(cmd))
+    proc = subprocess.run(cmd, cwd=repo_root, check=False)
+    return proc.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/hooks/run_trivy_sbom.py
+++ b/scripts/hooks/run_trivy_sbom.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Generate a CycloneDX SBOM via Trivy."""
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+IMAGE = "docker.io/aquasec/trivy:0.52.1"
+OUTPUT_NAME = "trivy-sbom.json"
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    artifacts_dir = repo_root / "artifacts" / "sbom"
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+    output_path = artifacts_dir / OUTPUT_NAME
+
+    podman = shutil.which("podman")
+    if not podman:
+        print("podman is required to run Trivy SBOM generation.")
+        return 1
+
+    cmd = [
+        podman,
+        "run",
+        "--rm",
+        "--security-opt",
+        "label=disable",
+        "--mount",
+        f"type=bind,source={repo_root},target=/workspace,ro",
+        "-w",
+        "/workspace",
+        IMAGE,
+        "fs",
+        "--format",
+        "cyclonedx",
+        "--output",
+        f"/workspace/{output_path.relative_to(repo_root)}",
+        "/workspace",
+    ]
+    print("Running:", " ".join(cmd))
+    proc = subprocess.run(cmd, check=False)
+    if proc.returncode == 0:
+        print(f"SBOM saved to {output_path}")
+    return proc.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/hooks/run_trivy_vuln.py
+++ b/scripts/hooks/run_trivy_vuln.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Run Trivy vulnerability scan via Podman."""
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+IMAGE = "docker.io/aquasec/trivy:0.52.1"
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    cache_dir = repo_root / "var" / "cache" / "trivy"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    podman = shutil.which("podman")
+    if not podman:
+        print("podman is required to run Trivy scans.")
+        return 1
+
+    mounts = [
+        f"type=bind,source={repo_root},target=/workspace,ro",
+        f"type=bind,source={cache_dir},target=/root/.cache",
+    ]
+
+    cmd = [
+        podman,
+        "run",
+        "--rm",
+        "--security-opt",
+        "label=disable",
+        "--mount",
+        mounts[0],
+        "--mount",
+        mounts[1],
+        "-w",
+        "/workspace",
+        IMAGE,
+        "fs",
+        "--exit-code",
+        "1",
+        "--severity",
+        "HIGH,CRITICAL",
+        "--scanners",
+        "vuln,misconfig",
+        "/workspace",
+    ]
+    print("Running:", " ".join(cmd))
+    proc = subprocess.run(cmd, check=False)
+    return proc.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/hooks/run_vulture.py
+++ b/scripts/hooks/run_vulture.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Run Vulture dead-code scanning via uv."""
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+TARGETS = ["server", "client"]
+MIN_CONFIDENCE = "80"
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    uv = shutil.which("uv")
+    if not uv:
+        print("uv is required to run Vulture.")
+        return 1
+
+    cmd = [
+        uv,
+        "tool",
+        "run",
+        "vulture",
+        *TARGETS,
+        "--min-confidence",
+        MIN_CONFIDENCE,
+    ]
+    print("Running:", " ".join(cmd))
+    proc = subprocess.run(cmd, cwd=repo_root, check=False)
+    return proc.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/hooks/run_xenon.py
+++ b/scripts/hooks/run_xenon.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Run Xenon complexity budget checks via uv."""
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+MAX_ABSOLUTE = "B"
+MAX_MODULES = "B"
+MAX_AVERAGE = "B"
+TARGETS = ["server", "client"]
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    uv = shutil.which("uv")
+    if not uv:
+        print("uv is required to run Xenon.")
+        return 1
+
+    cmd = [
+        uv,
+        "tool",
+        "run",
+        "xenon",
+        *TARGETS,
+        "--max-absolute",
+        MAX_ABSOLUTE,
+        "--max-modules",
+        MAX_MODULES,
+        "--max-average",
+        MAX_AVERAGE,
+    ]
+    print("Running:", " ".join(cmd))
+    proc = subprocess.run(cmd, cwd=repo_root, check=False)
+    return proc.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Fixes #139

## Summary
- add .pre-commit-config.yaml, ruff.toml, and repo-wide .gitattributes tweaks
- add uv-powered helper scripts under scripts/hooks/ for schema regen, Ruff, Bandit, Xenon, Vulture, Trivy, hadolint, and Podman smoke tests
- document default vs manual hook stages in docs/dev_hooks.md and describe the workflow in docs/nix_vs_container.md

## Testing
- python scripts/hooks/regen_packet_schema.py
- uv tool run pre-commit run --all-files
- uv tool run pre-commit run --hook-stage manual --all-files