### PR TITLE
Trim trailing whitespace

### DIFF
--- a/client/sound_cacher.py
+++ b/client/sound_cacher.py
@@ -20,7 +20,7 @@ class SoundCacher:
         if o is None:
             # Silent mode - no audio device available
             return None
-            
+
         if file_name not in self.cache:
             with open(file_name, "rb") as f:
                 self.cache[file_name] = ctypes.create_string_buffer(f.read())

--- a/client/sound_manager.py
+++ b/client/sound_manager.py
@@ -542,7 +542,7 @@ class SoundManager:
                 if o is None:
                     # Silent mode - skip ambience
                     return
-                
+
                 intro_path = (
                     os.path.join(self.sounds_folder, intro_name) if intro_name else None
                 )

--- a/client/ui/menu_list.py
+++ b/client/ui/menu_list.py
@@ -194,7 +194,7 @@ class MenuList(wx.ListBox):
         """Play the appropriate sound for the selected item."""
         if not self.sound_manager:
             return
-        
+
         custom_sound = None
         if selection_index != wx.NOT_FOUND:
             try:
@@ -204,7 +204,7 @@ class MenuList(wx.ListBox):
             except (wx._core.wxAssertionError, RuntimeError, AttributeError):
                 # Silently ignore when client data is not available
                 pass
-        
+
         if custom_sound:
             self.sound_manager.play(custom_sound)
         else:

--- a/installer/linux/arch/README.md
+++ b/installer/linux/arch/README.md
@@ -6,4 +6,4 @@ To publish packages manually:
 1. Update `pkgver/pkgrel` (handled automatically in CI, but document expected values).
 2. Run `updpkgsums` after pointing `source` to actual tarballs if you build by hand.
 3. Use `makepkg -si` or push to AUR repositories (`playpalace-client-bin`, `playpalace-server-bin`).
-4. Ensure systemd units/configs live under `/usr/lib/systemd/system/` and `/etc/playpalace/` (current PKGBUILD installs the unit from `installer/linux/systemd`). 
+4. Ensure systemd units/configs live under `/usr/lib/systemd/system/` and `/etc/playpalace/` (current PKGBUILD installs the unit from `installer/linux/systemd`).

--- a/server/core/administration.py
+++ b/server/core/administration.py
@@ -1109,7 +1109,7 @@ class AdministrationMixin:
 
         bots_cleared, tables_killed = self._virtual_bots.clear_bots()
         if bots_cleared > 0:
-            owner.speak_l( 
+            owner.speak_l(
                 "virtual-bots-cleared",
                 bots=bots_cleared,
                 tables=tables_killed,
@@ -1129,7 +1129,7 @@ class AdministrationMixin:
             return
 
         status = self._virtual_bots.get_status()
-        owner.speak_l( 
+        owner.speak_l(
             "virtual-bots-status-report",
             total=status["total"],
             online=status["online"],

--- a/server/games/crazyeights/game.py
+++ b/server/games/crazyeights/game.py
@@ -729,14 +729,14 @@ class CrazyEightsGame(Game):
         deck_count = self.deck.size()
         if deck_count > 0:
             parts.append(Localization.get(locale, "crazyeights-deck-count", count=deck_count))
-        
+
         if parts:
             text = ", ".join(parts)
         elif self.players:
             text = Localization.get(locale, "crazyeights-no-hands")
         else:
             text = Localization.get(locale, "crazyeights-no-players")
-        
+
         user.speak(text)
 
     def _action_check_turn_timer(self, player: Player, action_id: str) -> None:
@@ -1117,7 +1117,7 @@ class CrazyEightsGame(Game):
 
     def _end_round(self, winner: CrazyEightsPlayer, last_card: Card | None) -> None:
         self._stop_turn_loop()
-        
+
         # Calculate scores before clearing hands
         points_from: list[tuple[CrazyEightsPlayer, int]] = []
         total = 0
@@ -1143,7 +1143,7 @@ class CrazyEightsGame(Game):
         for p in self.players:
             if isinstance(p, CrazyEightsPlayer):
                 p.hand = []
-        
+
         self.rebuild_all_menus()
 
         if winner.score >= self.options.winning_score:
@@ -1242,12 +1242,12 @@ class CrazyEightsGame(Game):
                 continue
             card_text = self.format_card(card, user.locale)
             one_card_text = Localization.get(user.locale, 'crazyeights-one-card') if len(player.hand) == 1 else ""
-            
+
             if p.id == player.id:
                 msg = Localization.get(user.locale, "crazyeights-you-play", card=card_text)
             else:
                 msg = Localization.get(user.locale, "crazyeights-player-plays", player=player.name, card=card_text)
-            
+
             if one_card_text:
                 user.speak(f"{msg} {one_card_text}", buffer="table")
             else:

--- a/server/network/websocket_server.py
+++ b/server/network/websocket_server.py
@@ -128,7 +128,7 @@ class WebSocketServer:
                     file=sys.stderr,
                 )
             raise SystemExit(1) from exc
-        
+
         protocol = "wss" if self._ssl_context else "ws"
         print(f"WebSocket server started on {protocol}://{self.host}:{self.port}")
 

--- a/server/plans/localization_and_messages.md
+++ b/server/plans/localization_and_messages.md
@@ -1,6 +1,6 @@
 # messages and localization
 PlayPalace v11 has the ability to be translated into other languages.
-For translation, we use Mozilla Fluent, which is a high quality localization system 
+For translation, we use Mozilla Fluent, which is a high quality localization system
 
 It naturally supports clean separation of things into multiple files. We expect this will make it much easier, as languages don't all have to be in one big file.
 We suggest one file for each game, and one file for general UI, though we're willing to change this later as needed.

--- a/web-client/README.md
+++ b/web-client/README.md
@@ -1,7 +1,7 @@
 # PlayPalace Web Client
 
 This is an early version of a web client for the PlayPalace. is designed to connect to a server you indicate and can be hosted on the web.
- 
+
 ## Public Setup
 
 1. Copy  the /web-client directory to a public website location.
@@ -15,7 +15,7 @@ This is an early version of a web client for the PlayPalace. is designed to conn
    - `python3 -m http.server 8080`
 3. Open:
    - `http://127.0.0.1:8080/web-client/`
-   
+
 ## How it Works
 
 When viewing the web client from a computer, you can tab between game, history, and chat similar to the desktop client. Most desktop hotkeys work here as well.


### PR DESCRIPTION
## Summary
- remove stray trailing whitespace from docs, localization files, and shared python modules that the `trailing-whitespace` hook enforces
- keeping these files clean prevents future diffs from being polluted by editor auto-fixes and keeps lints green for everyone touching these areas

## Testing
- pre-commit run trailing-whitespace --all-files
