### PR TITLE
Normalize packet schema file newline generation

### DIFF
--- a/server/tools/export_packet_schema.py
+++ b/server/tools/export_packet_schema.py
@@ -29,7 +29,7 @@ def _default_paths() -> tuple[Path, Path]:
 
 def _write_schema(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- append a trailing newline when writing exported packet schema JSON
- avoids EOF newline drift in generated schema files

## Testing
- uv run pytest tests/test_packet_schemas.py::test_packet_schema_files_are_up_to_date