### PR TITLE
Fix: Desktop Refresh Tokens, Typing Sound, Server Localization FlagFix desktop auth and localization warmup behavior

### DIFF
--- a/clients/desktop/network_manager.py
+++ b/clients/desktop/network_manager.py
@@ -110,9 +110,9 @@ class NetworkManager:
             self.should_stop = False
             self.server_url = server_url
             self.server_id = getattr(self.main_window, "server_id", None)
-            if refresh_token:
-                self.refresh_token = refresh_token
-                self.refresh_expires_at = refresh_expires_at
+            # Keep refresh token state aligned with the credentials used for this connection.
+            self.refresh_token = refresh_token or None
+            self.refresh_expires_at = refresh_expires_at if refresh_token else None
 
             # Start async thread
             self.thread = threading.Thread(
@@ -155,9 +155,7 @@ class NetworkManager:
             self.ws = websocket
             self.connected = True
 
-            if self._session_valid():
-                await self._send_authorize(websocket, username, password)
-            elif self._refresh_valid():
+            if self._refresh_valid():
                 await self._send_refresh_session(websocket, username)
                 # Wait for the server's response to the refresh attempt.
                 # If it fails (or the server silently drops the packet),

--- a/clients/desktop/ui/main_window.py
+++ b/clients/desktop/ui/main_window.py
@@ -1022,7 +1022,12 @@ class MainWindow(wx.Frame):
             self.switch_to_list_mode()
             return  # Don't process the Escape key
 
-        if key_code in self._NAVIGATION_KEYS or event.ShiftDown() or event.ControlDown() or event.AltDown() or event.MetaDown():
+        if (
+            key_code in self._NAVIGATION_KEYS
+            or event.ControlDown()
+            or event.AltDown()
+            or event.MetaDown()
+        ):
             self._pending_edit_clear = False
             event.Skip()
             return
@@ -1090,7 +1095,6 @@ class MainWindow(wx.Frame):
     def _should_defer_multiline_to_default(self, event, key_code: int) -> bool:
         if (
             key_code in self._NAVIGATION_KEYS
-            or event.ShiftDown()
             or event.ControlDown()
             or event.AltDown()
             or event.MetaDown()

--- a/server/locales/ar/main.ftl
+++ b/server/locales/ar/main.ftl
@@ -439,3 +439,5 @@ virtual-bots-profiles-line = { $profile } ({ $bot_count } { $bot_count ->
    *[other] بوت
 }) التجاوزات: { $overrides }.
 virtual-bots-profiles-no-overrides = يرث الإعدادات الأساسية
+
+localization-in-progress-try-again = جارٍ إعداد الترجمة. يُرجى المحاولة مرة أخرى بعد دقيقة.

--- a/server/locales/cs/main.ftl
+++ b/server/locales/cs/main.ftl
@@ -391,3 +391,5 @@ virtual-bots-profiles-header = Profily: { $count } definováno (výchozí: { $de
 virtual-bots-profiles-empty = Nejsou definovány žádné profily.
 virtual-bots-profiles-line = { $profile } ({ $bot_count } botů) přepsání: { $overrides }.
 virtual-bots-profiles-no-overrides = dědí základní konfiguraci
+
+localization-in-progress-try-again = Lokalizace se stále načítá. Zkuste to prosím za minutu znovu.

--- a/server/locales/de/main.ftl
+++ b/server/locales/de/main.ftl
@@ -353,3 +353,5 @@ virtual-bots-profiles-header = Profile: { $count } definiert (Standard: { $defau
 virtual-bots-profiles-empty = Keine Profile definiert.
 virtual-bots-profiles-line = { $profile } ({ $bot_count } Bots) Überschreibungen: { $overrides }.
 virtual-bots-profiles-no-overrides = erbt Basiskonfiguration
+
+localization-in-progress-try-again = Die Lokalisierung wird noch geladen. Bitte versuchen Sie es in einer Minute erneut.

--- a/server/locales/en/main.ftl
+++ b/server/locales/en/main.ftl
@@ -353,3 +353,5 @@ virtual-bots-profiles-header = Profiles: { $count } defined (default: { $default
 virtual-bots-profiles-empty = No profiles are defined.
 virtual-bots-profiles-line = { $profile } ({ $bot_count } bots) overrides: { $overrides }.
 virtual-bots-profiles-no-overrides = inherits base configuration
+
+localization-in-progress-try-again = Localization in progress. Please try again in a minute.

--- a/server/locales/es/main.ftl
+++ b/server/locales/es/main.ftl
@@ -353,3 +353,5 @@ virtual-bots-profiles-header = Perfiles: { $count } definidos (predeterminado: {
 virtual-bots-profiles-empty = No hay perfiles definidos.
 virtual-bots-profiles-line = { $profile } ({ $bot_count } bots) anulaciones: { $overrides }.
 virtual-bots-profiles-no-overrides = hereda configuración base
+
+localization-in-progress-try-again = La localización está en progreso. Vuelve a intentarlo en un minuto.

--- a/server/locales/fa/main.ftl
+++ b/server/locales/fa/main.ftl
@@ -353,3 +353,5 @@ virtual-bots-profiles-header = پروفایل‌ها: { $count } تعریف‌ش
 virtual-bots-profiles-empty = هیچ پروفایلی تعریف نشده است.
 virtual-bots-profiles-line = { $profile } ({ $bot_count } ربات) بازنویسی‌ها: { $overrides }.
 virtual-bots-profiles-no-overrides = ارث‌بری پیکربندی پایه
+
+localization-in-progress-try-again = بومی‌سازی در حال انجام است. لطفاً یک دقیقه دیگر دوباره تلاش کنید.

--- a/server/locales/fr/main.ftl
+++ b/server/locales/fr/main.ftl
@@ -357,3 +357,5 @@ virtual-bots-profiles-header = Profils : { $count } définis (par défaut : { $d
 virtual-bots-profiles-empty = Aucun profil n'est défini.
 virtual-bots-profiles-line = { $profile } ({ $bot_count } bots) remplacements : { $overrides }.
 virtual-bots-profiles-no-overrides = hérite de la configuration de base
+
+localization-in-progress-try-again = La localisation est en cours. Veuillez réessayer dans une minute.

--- a/server/locales/hi/main.ftl
+++ b/server/locales/hi/main.ftl
@@ -353,3 +353,5 @@ virtual-bots-profiles-header = प्रोफाइल: { $count } परिभ
 virtual-bots-profiles-empty = कोई प्रोफाइल परिभाषित नहीं हैं।
 virtual-bots-profiles-line = { $profile } ({ $bot_count } बॉट) ओवरराइड: { $overrides }।
 virtual-bots-profiles-no-overrides = आधार कॉन्फ़िगरेशन विरासत में मिलता है
+
+localization-in-progress-try-again = स्थानीयकरण जारी है। कृपया एक मिनट बाद फिर प्रयास करें।

--- a/server/locales/hr/main.ftl
+++ b/server/locales/hr/main.ftl
@@ -353,3 +353,5 @@ virtual-bots-profiles-header = Profili: { $count } definirano (zadano: { $defaul
 virtual-bots-profiles-empty = Nisu definirani profili.
 virtual-bots-profiles-line = { $profile } ({ $bot_count } botova) nadjačava: { $overrides }.
 virtual-bots-profiles-no-overrides = nasljeđuje osnovnu konfiguraciju
+
+localization-in-progress-try-again = Lokalizacija je u tijeku. Pokušajte ponovno za minutu.

--- a/server/locales/hu/main.ftl
+++ b/server/locales/hu/main.ftl
@@ -353,3 +353,5 @@ virtual-bots-profiles-header = Profilok: { $count } definiálva (alapértelmezet
 virtual-bots-profiles-empty = Nincsenek definiált profilok.
 virtual-bots-profiles-line = { $profile } ({ $bot_count } bot) felülírások: { $overrides }.
 virtual-bots-profiles-no-overrides = örökli az alap konfigurációt
+
+localization-in-progress-try-again = A lokalizáció folyamatban van. Kérjük, próbálja újra egy perc múlva.

--- a/server/locales/id/main.ftl
+++ b/server/locales/id/main.ftl
@@ -353,3 +353,5 @@ virtual-bots-profiles-header = Profil: { $count } didefinisikan (default: { $def
 virtual-bots-profiles-empty = Tidak ada profil yang didefinisikan.
 virtual-bots-profiles-line = { $profile } ({ $bot_count } bot) override: { $overrides }.
 virtual-bots-profiles-no-overrides = mewarisi konfigurasi dasar
+
+localization-in-progress-try-again = Lokalisasi sedang diproses. Silakan coba lagi dalam satu menit.

--- a/server/locales/it/main.ftl
+++ b/server/locales/it/main.ftl
@@ -353,3 +353,5 @@ virtual-bots-profiles-header = Profili: { $count } definiti (predefinito: { $def
 virtual-bots-profiles-empty = Nessun profilo definito.
 virtual-bots-profiles-line = { $profile } ({ $bot_count } bot) sostituzioni: { $overrides }.
 virtual-bots-profiles-no-overrides = eredita configurazione base
+
+localization-in-progress-try-again = La localizzazione è in corso. Riprova tra un minuto.

--- a/server/locales/ja/main.ftl
+++ b/server/locales/ja/main.ftl
@@ -341,3 +341,5 @@ virtual-bots-profiles-header = プロファイル: { $count }個定義済み(デ
 virtual-bots-profiles-empty = プロファイルは定義されていません。
 virtual-bots-profiles-line = { $profile }({ $bot_count }個のボット)オーバーライド: { $overrides }。
 virtual-bots-profiles-no-overrides = ベース設定を継承
+
+localization-in-progress-try-again = ローカライズ処理中です。1分後にもう一度お試しください。

--- a/server/locales/ko/main.ftl
+++ b/server/locales/ko/main.ftl
@@ -341,3 +341,5 @@ virtual-bots-profiles-header = 프로필: { $count }개 정의됨 (기본: { $de
 virtual-bots-profiles-empty = 정의된 프로필이 없습니다.
 virtual-bots-profiles-line = { $profile } ({ $bot_count }개 봇) 재정의: { $overrides }.
 virtual-bots-profiles-no-overrides = 기본 구성 상속
+
+localization-in-progress-try-again = 현지화 작업이 진행 중입니다. 1분 후에 다시 시도해 주세요.

--- a/server/locales/mn/main.ftl
+++ b/server/locales/mn/main.ftl
@@ -353,3 +353,5 @@ virtual-bots-profiles-header = Профайлууд: { $count } тодорхой
 virtual-bots-profiles-empty = Профайл тодорхойлоогүй байна.
 virtual-bots-profiles-line = { $profile } ({ $bot_count } бот) дарж бичих: { $overrides }.
 virtual-bots-profiles-no-overrides = үндсэн тохиргооноос өвлөнө
+
+localization-in-progress-try-again = Нутагшуулалт хийгдэж байна. Нэг минутын дараа дахин оролдоно уу.

--- a/server/locales/nl/main.ftl
+++ b/server/locales/nl/main.ftl
@@ -353,3 +353,5 @@ virtual-bots-profiles-header = Profielen: { $count } gedefinieerd (standaard: { 
 virtual-bots-profiles-empty = Geen profielen zijn gedefinieerd.
 virtual-bots-profiles-line = { $profile } ({ $bot_count } bots) overschrijvingen: { $overrides }.
 virtual-bots-profiles-no-overrides = erft basisconfiguratie
+
+localization-in-progress-try-again = Lokalisatie is bezig. Probeer het over een minuut opnieuw.

--- a/server/locales/pl/main.ftl
+++ b/server/locales/pl/main.ftl
@@ -332,3 +332,5 @@ virtual-bots-profiles-header = Profiles: { $count } defined (default: { $default
 virtual-bots-profiles-empty = No profiles are defined.
 virtual-bots-profiles-line = { $profile } ({ $bot_count } bots) overrides: { $overrides }.
 virtual-bots-profiles-no-overrides = inherits base configuration
+
+localization-in-progress-try-again = Lokalizacja jest w toku. Spróbuj ponownie za minutę.

--- a/server/locales/pt/main.ftl
+++ b/server/locales/pt/main.ftl
@@ -293,3 +293,5 @@ virtual-bots-profiles-header = Profiles: { $count } defined (default: { $default
 virtual-bots-profiles-empty = No profiles are defined.
 virtual-bots-profiles-line = { $profile } ({ $bot_count } bots) overrides: { $overrides }.
 virtual-bots-profiles-no-overrides = inherits base configuration
+
+localization-in-progress-try-again = A localização está em andamento. Tente novamente em um minuto.

--- a/server/locales/ro/main.ftl
+++ b/server/locales/ro/main.ftl
@@ -357,3 +357,5 @@ virtual-bots-profiles-header = Profiluri: { $count } definite (implicit: { $defa
 virtual-bots-profiles-empty = Niciun profil definit.
 virtual-bots-profiles-line = { $profile } ({ $bot_count } boți) suprascrie: { $overrides }.
 virtual-bots-profiles-no-overrides = moștenește configurația de bază
+
+localization-in-progress-try-again = Localizarea este în curs. Vă rugăm să încercați din nou peste un minut.

--- a/server/locales/ru/main.ftl
+++ b/server/locales/ru/main.ftl
@@ -374,3 +374,5 @@ virtual-bots-profiles-header = Profiles: { $count } defined (default: { $default
 virtual-bots-profiles-empty = No profiles are defined.
 virtual-bots-profiles-line = { $profile } ({ $bot_count } bots) overrides: { $overrides }.
 virtual-bots-profiles-no-overrides = inherits base configuration
+
+localization-in-progress-try-again = Локализация ещё загружается. Пожалуйста, попробуйте снова через минуту.

--- a/server/locales/sk/main.ftl
+++ b/server/locales/sk/main.ftl
@@ -361,3 +361,5 @@ virtual-bots-profiles-header = Profily: { $count } definovaných (predvolený: {
 virtual-bots-profiles-empty = Žiadne profily nie sú definované.
 virtual-bots-profiles-line = { $profile } ({ $bot_count } botov) prepíše: { $overrides }.
 virtual-bots-profiles-no-overrides = dedí základnú konfiguráciu
+
+localization-in-progress-try-again = Lokalizácia sa stále načítava. Skúste to prosím znova o minútu.

--- a/server/locales/sl/main.ftl
+++ b/server/locales/sl/main.ftl
@@ -353,3 +353,5 @@ virtual-bots-profiles-header = Profili: { $count } definiranih (privzeto: { $def
 virtual-bots-profiles-empty = Ni definiranih profilov.
 virtual-bots-profiles-line = { $profile } ({ $bot_count } botov) prepiše: { $overrides }.
 virtual-bots-profiles-no-overrides = podeduje osnovno konfiguracijo
+
+localization-in-progress-try-again = Lokalizacija je v teku. Poskusite znova čez minuto.

--- a/server/locales/sv/main.ftl
+++ b/server/locales/sv/main.ftl
@@ -353,3 +353,5 @@ virtual-bots-profiles-header = Profiler: { $count } definierade (standard: { $de
 virtual-bots-profiles-empty = Inga profiler är definierade.
 virtual-bots-profiles-line = { $profile } ({ $bot_count } botar) åsidosätter: { $overrides }.
 virtual-bots-profiles-no-overrides = ärver baskonfiguration
+
+localization-in-progress-try-again = Lokalisering pågår. Försök igen om en minut.

--- a/server/locales/th/main.ftl
+++ b/server/locales/th/main.ftl
@@ -341,3 +341,5 @@ virtual-bots-profiles-header = โปรไฟล์: { $count } กำหนด
 virtual-bots-profiles-empty = ไม่มีโปรไฟล์ที่กำหนดไว้
 virtual-bots-profiles-line = { $profile } ({ $bot_count } บอต) แทนที่: { $overrides }
 virtual-bots-profiles-no-overrides = สืบทอดการกำหนดค่าพื้นฐาน
+
+localization-in-progress-try-again = กำลังโหลดการแปลภาษา โปรดลองอีกครั้งในอีกหนึ่งนาที

--- a/server/locales/tr/main.ftl
+++ b/server/locales/tr/main.ftl
@@ -353,3 +353,5 @@ virtual-bots-profiles-header = Profiller: { $count } tanımlı (varsayılan: { $
 virtual-bots-profiles-empty = Profil tanımlanmamış.
 virtual-bots-profiles-line = { $profile } ({ $bot_count } bot) geçersiz kılmalar: { $overrides }.
 virtual-bots-profiles-no-overrides = temel yapılandırmayı miras alır
+
+localization-in-progress-try-again = Yerelleştirme sürüyor. Lütfen bir dakika sonra tekrar deneyin.

--- a/server/locales/uk/main.ftl
+++ b/server/locales/uk/main.ftl
@@ -353,3 +353,5 @@ virtual-bots-profiles-header = Профілі: { $count } визначено (з
 virtual-bots-profiles-empty = Не визначено профілів.
 virtual-bots-profiles-line = { $profile } ({ $bot_count } ботів) перевизначення: { $overrides }.
 virtual-bots-profiles-no-overrides = успадковує базову конфігурацію
+
+localization-in-progress-try-again = Локалізація ще завантажується. Будь ласка, спробуйте знову за хвилину.

--- a/server/locales/vi/main.ftl
+++ b/server/locales/vi/main.ftl
@@ -353,3 +353,5 @@ virtual-bots-profiles-header = Hồ sơ: { $count } đã định nghĩa (mặc �
 virtual-bots-profiles-empty = Chưa định nghĩa hồ sơ nào.
 virtual-bots-profiles-line = { $profile } ({ $bot_count } bots) ghi đè: { $overrides }.
 virtual-bots-profiles-no-overrides = kế thừa cấu hình gốc
+
+localization-in-progress-try-again = Bản địa hóa đang được xử lý. Vui lòng thử lại sau một phút.

--- a/server/locales/zh/main.ftl
+++ b/server/locales/zh/main.ftl
@@ -283,3 +283,5 @@ virtual-bots-profiles-header = Profiles: { $count } defined (default: { $default
 virtual-bots-profiles-empty = No profiles are defined.
 virtual-bots-profiles-line = { $profile } ({ $bot_count } bots) overrides: { $overrides }.
 virtual-bots-profiles-no-overrides = inherits base configuration
+
+localization-in-progress-try-again = 本地化正在进行中。请在一分钟后重试。

--- a/server/locales/zu/main.ftl
+++ b/server/locales/zu/main.ftl
@@ -353,3 +353,5 @@ virtual-bots-profiles-header = Amaphrofayili: { $count } achazwe (okuzenzakalela
 virtual-bots-profiles-empty = Akukho maphrofayili achazwe.
 virtual-bots-profiles-line = { $profile } (ama-bots angu-{ $bot_count }) kweqiwe: { $overrides }.
 virtual-bots-profiles-no-overrides = idla ifa ukucushwa okuyisisekelo
+
+localization-in-progress-try-again = Ukuhumusha kusaqhubeka. Sicela uzame futhi emzuzwini.

--- a/server/tests/test_server_core_misc.py
+++ b/server/tests/test_server_core_misc.py
@@ -205,7 +205,7 @@ async def test_start_localization_warmup_schedules(monkeypatch, server):
 
     server._start_localization_warmup()
 
-    assert server._localization_gate_registered is True
+    assert server._localization_gate_registered is False
     assert loop.tasks, "expected task scheduling"
 
 


### PR DESCRIPTION
  ## Summary

  This PR fixes desktop auth/session handling and server localization warmup behavior.

  ### Desktop client

  - Fixed typing sounds so uppercase letters also play typing audio (Shift no longer suppresses printable typing sounds).
  - Fixed reconnect/login auth flow to prefer refresh token when available, with password fallback.
  - Aligned refresh token state with the credentials passed to connect(...) to avoid stale-token behavior.
  - Added/updated desktop auth tests for refresh-first behavior.

  ### Server

  - Fixed localization warmup so non---preload-locales startup is truly non-blocking (clients can connect while warmup runs).
  - Added warmup guards for language menu actions:
      - If localization warmup is active, selecting language now returns a user message instead of hanging.
      - Message key is localized across all locales.
  - Fixed shutdown behavior during localization warmup by running background warmup in a daemon thread path so Ctrl+C shutdown can return cleanly.

  ## Testing

  - cd server && uv run pytest tests/test_server_options_menus.py tests/test_server_core_utils.py tests/test_server_core_misc.py tests/test_server_lifecycle.py tests/
    test_localization_cache.py -q
  - cd server && uv run pytest tests/test_server_options_menus.py tests/test_server_core_utils.py tests/test_server_core_misc.py tests/test_server_lifecycle.py -q
  - python3 -m py_compile clients/desktop/network_manager.py clients/desktop/ui/main_window.py server/core/server.py

  All executed checks passed in this environment.


› Explain this codebase

  ? for shortcuts                                                                                                                                                          25% context left