### PR TITLE
Add scheduled broadcast platform API

### DIFF
--- a/server/game_utils/game_communication_mixin.py
+++ b/server/game_utils/game_communication_mixin.py
@@ -105,8 +105,9 @@ class GameCommunicationMixin:
             **kwargs: Fluent arguments forwarded to the message.
         """
         target_tick = self.sound_scheduler_tick + delay_ticks
+        exclude_id = exclude.id if exclude is not None else None
         self.scheduled_broadcasts.append(
-            (target_tick, "broadcast", message_id, buffer, None, None, kwargs, exclude)
+            (target_tick, "broadcast", message_id, buffer, None, None, kwargs, exclude_id)
         )
 
     def schedule_broadcast_personal_l(
@@ -129,8 +130,9 @@ class GameCommunicationMixin:
             **kwargs: Fluent arguments forwarded to both messages.
         """
         target_tick = self.sound_scheduler_tick + delay_ticks
+        # Store player ID (str) rather than the player object so the entry is JSON-serializable.
         self.scheduled_broadcasts.append(
-            (target_tick, "personal", personal_message_id, buffer, player, others_message_id, kwargs, None)
+            (target_tick, "personal", personal_message_id, buffer, player.id, others_message_id, kwargs, None)
         )
 
     def process_scheduled_broadcasts(self) -> None:
@@ -141,11 +143,14 @@ class GameCommunicationMixin:
         current_tick = self.sound_scheduler_tick
         remaining = []
         for entry in self.scheduled_broadcasts:
-            tick, kind, message_id, buffer, player, others_id, kwargs, exclude = entry
+            tick, kind, message_id, buffer, player_id, others_id, kwargs, exclude_id = entry
             if tick <= current_tick:
                 if kind == "personal":
-                    self.broadcast_personal_l(player, message_id, others_id, buffer, **kwargs)
+                    player = next((p for p in self.players if p.id == player_id), None)
+                    if player:
+                        self.broadcast_personal_l(player, message_id, others_id, buffer, **kwargs)
                 else:
+                    exclude = next((p for p in self.players if p.id == exclude_id), None) if exclude_id else None
                     self.broadcast_l(message_id, buffer, exclude=exclude, **kwargs)
             else:
                 remaining.append(entry)

--- a/server/game_utils/game_communication_mixin.py
+++ b/server/game_utils/game_communication_mixin.py
@@ -87,6 +87,70 @@ class GameCommunicationMixin:
             if u:
                 u.speak_l(others_message_id, buffer, player=player.name, **kwargs)
 
+    def schedule_broadcast_l(
+        self,
+        message_id: str,
+        delay_ticks: int,
+        buffer: str = "table",
+        exclude: "Player | None" = None,
+        **kwargs,
+    ) -> None:
+        """Schedule a localized broadcast to fire after delay_ticks ticks.
+
+        Args:
+            message_id: Fluent message ID.
+            delay_ticks: Ticks to wait before sending (uses sound_scheduler_tick).
+            buffer: Speech buffer name.
+            exclude: Player to exclude, if any.
+            **kwargs: Fluent arguments forwarded to the message.
+        """
+        target_tick = self.sound_scheduler_tick + delay_ticks
+        self.scheduled_broadcasts.append(
+            (target_tick, "broadcast", message_id, buffer, None, None, kwargs, exclude)
+        )
+
+    def schedule_broadcast_personal_l(
+        self,
+        player: "Player",
+        personal_message_id: str,
+        others_message_id: str,
+        delay_ticks: int,
+        buffer: str = "table",
+        **kwargs,
+    ) -> None:
+        """Schedule a personal/others broadcast pair to fire after delay_ticks ticks.
+
+        Args:
+            player: The player who receives the personal message.
+            personal_message_id: Fluent message ID for that player.
+            others_message_id: Fluent message ID for everyone else.
+            delay_ticks: Ticks to wait before sending (uses sound_scheduler_tick).
+            buffer: Speech buffer name.
+            **kwargs: Fluent arguments forwarded to both messages.
+        """
+        target_tick = self.sound_scheduler_tick + delay_ticks
+        self.scheduled_broadcasts.append(
+            (target_tick, "personal", personal_message_id, buffer, player, others_message_id, kwargs, None)
+        )
+
+    def process_scheduled_broadcasts(self) -> None:
+        """Fire any scheduled broadcasts whose tick has arrived. Called in on_tick()."""
+        if not self.scheduled_broadcasts:
+            return
+
+        current_tick = self.sound_scheduler_tick
+        remaining = []
+        for entry in self.scheduled_broadcasts:
+            tick, kind, message_id, buffer, player, others_id, kwargs, exclude = entry
+            if tick <= current_tick:
+                if kind == "personal":
+                    self.broadcast_personal_l(player, message_id, others_id, buffer, **kwargs)
+                else:
+                    self.broadcast_l(message_id, buffer, exclude=exclude, **kwargs)
+            else:
+                remaining.append(entry)
+        self.scheduled_broadcasts = remaining
+
     def label_l(self, message_id: str) -> Callable[["Game", "Player"], str]:
         """
         Create a localized label callable for use in action definitions.

--- a/server/game_utils/menu_management_mixin.py
+++ b/server/game_utils/menu_management_mixin.py
@@ -94,8 +94,21 @@ class MenuManagementMixin:
                 label = f"{label}; {unavailable}"
             items.append(MenuItem(text=label, id=resolved.action.id, sound=resolved.sound))
 
+        # When a specific item is being focused by ID, also compute its 1-based
+        # position and pass it through. user.update_menu stores the position in
+        # _current_menus so that a subsequent rebuild_player_menu (which calls
+        # show_menu) can restore focus to the correct item even though show_menu
+        # uses a positional index rather than an ID.
+        position = None
+        if selection_id:
+            for i, item in enumerate(items, 1):
+                if item.id == selection_id:
+                    position = i
+                    break
+
         user.update_menu(
-            "turn_menu", items, selection_id=selection_id, play_selection_sound=play_selection_sound
+            "turn_menu", items, selection_id=selection_id, position=position,
+            play_selection_sound=play_selection_sound
         )
 
     def update_all_menus(self) -> None:

--- a/server/games/base.py
+++ b/server/games/base.py
@@ -147,6 +147,8 @@ class Game(
     # Sound scheduler state (serialized for persistence)
     scheduled_sounds: list = field(default_factory=list)  # [[tick, sound, vol, pan, pitch], ...]
     sound_scheduler_tick: int = 0  # Current tick counter
+    # Broadcast scheduler state (serialized for persistence)
+    scheduled_broadcasts: list = field(default_factory=list)  # see game_communication_mixin
     # Event queue state (serialized for persistence)
     event_queue: list[tuple[int, str, dict]] = field(
         default_factory=list
@@ -324,6 +326,7 @@ class Game(
         Subclasses should call super().on_tick() to ensure base functionality runs.
         """
         self.process_scheduled_sounds()
+        self.process_scheduled_broadcasts()
         # Check if duration estimation has completed
         self.check_estimate_completion()
 


### PR DESCRIPTION
## Summary

- Adds `schedule_broadcast_l` and `schedule_broadcast_personal_l` to `GameCommunicationMixin`, allowing games to stagger multi-message sequences over time so screen readers (NVDA etc.) have time to announce each line before the next arrives. Mirrors the existing `schedule_sound` / `process_scheduled_sounds` pattern and is processed each tick via the base `on_tick()` call.
- Fixes serialization: stores player/exclude IDs (strings) instead of live objects in the scheduled-broadcasts queue so entries survive JSON round-trips. Objects are resolved back to players at dispatch time.
- Passes the computed 1-based position through `update_menu` when a `selection_id` is given, so `rebuild_player_menu` can restore cursor focus to the correct slot after a menu rebuild.

## Test plan

- [ ] Verify `schedule_broadcast_l` and `schedule_broadcast_personal_l` are callable from a game and fire at the correct tick offset
- [ ] Verify serialization round-trip (save/load mid-game) does not drop or corrupt scheduled broadcast entries
- [ ] Verify menu focus is restored to the correct item after a rebuild that uses `selection_id`

**Note:** This PR is a prerequisite for the Phase 10 PR, which depends on these APIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)