### PR TITLE
Mile by Mile: touch-to-discard gated on confirm_destructive_actions

### DIFF
--- a/server/games/milebymile/game.py
+++ b/server/games/milebymile/game.py
@@ -12,7 +12,7 @@ import random
 from ..base import Game, Player
 from ..registry import register_game
 from ...game_utils.actions import Action, ActionSet, MenuInput, Visibility
-from server.core.users.base import MenuItem, EscapeBehavior
+from ...core.users.base import MenuItem, EscapeBehavior
 from ...game_utils.bot_helper import BotHelper
 from ...game_utils.game_result import GameResult, PlayerResult
 from ...game_utils.round_timer import RoundTransitionTimer
@@ -48,6 +48,8 @@ class MileByMileGame(Game):
     Hazards slow opponents, remedies fix problems, and safeties provide
     permanent protection. First team to reach the winning score wins.
     """
+
+    relevant_preferences = ["confirm_destructive_actions"]
 
     players: list[MileByMilePlayer] = field(default_factory=list)
     options: MileByMileOptions = field(default_factory=MileByMileOptions)
@@ -938,16 +940,24 @@ class MileByMileGame(Game):
         if self._can_play_card(player, card):
             self._play_card(player, slot, card, input_value)
         else:
-            # Can't play - bots auto-discard, humans get a yes/no prompt
+            # Can't play - bots auto-discard; humans get a yes/no prompt if
+            # they've enabled confirm_destructive_actions for this game.
             if player.is_bot:
                 self._discard_card(player, slot, card)
+                return
+            user = self.get_user(player)
+            if not user:
+                return
+            reason = self._get_unplayable_reason(player, card, user.locale)
+            card_name = self._get_localized_card_name(card, user.locale)
+            user.speak_l("milebymile-cant-play", card=card_name, reason=reason)
+            wants_confirm = user.preferences.get_effective(
+                "confirm_destructive_actions", game_type=self.get_type()
+            )
+            if wants_confirm:
+                self._show_discard_confirm(player, slot, user)
             else:
-                user = self.get_user(player)
-                if user:
-                    reason = self._get_unplayable_reason(player, card, user.locale)
-                    card_name = self._get_localized_card_name(card, user.locale)
-                    user.speak_l("milebymile-cant-play", card=card_name, reason=reason)
-                    self._show_discard_confirm(player, slot, user)
+                self._discard_card(player, slot, card)
 
     def _action_junk_card(self, player: Player, action_id: str) -> None:
         """Handle discarding the currently selected card (shift+enter or backspace keybind)."""
@@ -991,7 +1001,7 @@ class MileByMileGame(Game):
 
     def rebuild_player_menu(self, player, *, position: int | None = None) -> None:
         """Skip rebuilding if this player has a pending discard confirmation."""
-        if player.id in self._pending_actions:
+        if self._pending_actions.get(player.id) == "discard_confirm":
             return
         super().rebuild_player_menu(player, position=position)
 

--- a/server/games/milebymile/game.py
+++ b/server/games/milebymile/game.py
@@ -12,6 +12,7 @@ import random
 from ..base import Game, Player
 from ..registry import register_game
 from ...game_utils.actions import Action, ActionSet, MenuInput, Visibility
+from server.core.users.base import MenuItem, EscapeBehavior
 from ...game_utils.bot_helper import BotHelper
 from ...game_utils.game_result import GameResult, PlayerResult
 from ...game_utils.round_timer import RoundTransitionTimer
@@ -72,11 +73,13 @@ class MileByMileGame(Game):
         """Initialize runtime state."""
         super().__post_init__()
         self._round_timer = RoundTransitionTimer(self, delay_seconds=10.0)
+        self._pending_discard_slot: dict[str, int] = {}
 
     def rebuild_runtime_state(self) -> None:
         """Rebuild non-serialized state after deserialization."""
         super().rebuild_runtime_state()
         self._round_timer = RoundTransitionTimer(self, delay_seconds=10.0)
+        self._pending_discard_slot: dict[str, int] = {}
 
     @classmethod
     def get_name(cls) -> str:
@@ -935,7 +938,7 @@ class MileByMileGame(Game):
         if self._can_play_card(player, card):
             self._play_card(player, slot, card, input_value)
         else:
-            # Can't play - tell human players why, bots auto-discard
+            # Can't play - bots auto-discard, humans get a yes/no prompt
             if player.is_bot:
                 self._discard_card(player, slot, card)
             else:
@@ -944,6 +947,7 @@ class MileByMileGame(Game):
                     reason = self._get_unplayable_reason(player, card, user.locale)
                     card_name = self._get_localized_card_name(card, user.locale)
                     user.speak_l("milebymile-cant-play", card=card_name, reason=reason)
+                    self._show_discard_confirm(player, slot, user)
 
     def _action_junk_card(self, player: Player, action_id: str) -> None:
         """Handle discarding the currently selected card (shift+enter or backspace keybind)."""
@@ -984,6 +988,58 @@ class MileByMileGame(Game):
                 return
 
         self._discard_card(player, slot, card)
+
+    def rebuild_player_menu(self, player, *, position: int | None = None) -> None:
+        """Skip rebuilding if this player has a pending discard confirmation."""
+        if player.id in self._pending_actions:
+            return
+        super().rebuild_player_menu(player, position=position)
+
+    def _show_discard_confirm(self, player: MileByMilePlayer, slot: int, user) -> None:
+        """Show a yes/no confirmation to discard the unplayable card."""
+        self._pending_discard_slot[player.id] = slot
+        self._pending_actions[player.id] = "discard_confirm"
+        items = [
+            MenuItem(text=Localization.get(user.locale, "confirm-yes"), id="yes"),
+            MenuItem(text=Localization.get(user.locale, "confirm-no"), id="no"),
+        ]
+        user.show_menu(
+            "discard_confirm",
+            items,
+            multiletter=False,
+            escape_behavior=EscapeBehavior.SELECT_LAST,
+        )
+
+    def _handle_menu_event(self, player: "Player", event: dict) -> None:
+        """Handle menu events, routing discard confirmation."""
+        menu_id = event.get("menu_id")
+        if menu_id == "discard_confirm":
+            self._handle_discard_confirm(player, event)
+        else:
+            super()._handle_menu_event(player, event)
+
+    def _handle_discard_confirm(self, player: "Player", event: dict) -> None:
+        """Handle the discard confirmation menu response."""
+        self._pending_actions.pop(player.id, None)
+        slot = self._pending_discard_slot.pop(player.id, None)
+        if not isinstance(player, MileByMilePlayer):
+            self.rebuild_all_menus()
+            return
+        selection_id = event.get("selection_id", "")
+        if not selection_id:
+            selection = event.get("selection", 1) - 1
+            selection_id = "yes" if selection == 0 else "no"
+        if selection_id == "yes" and slot is not None and slot < len(player.hand):
+            card = player.hand[slot]
+            if not self.options.always_allow_discarding and self._can_play_card(player, card):
+                user = self.get_user(player)
+                if user:
+                    user.speak_l("milebymile-cant-discard-playable")
+                self.rebuild_all_menus()
+                return
+            self._discard_card(player, slot, card)
+            return
+        self.rebuild_all_menus()
 
     def _play_card(
         self,
@@ -1493,6 +1549,12 @@ class MileByMileGame(Game):
 
     def _start_turn(self) -> None:
         """Start a player's turn."""
+        # Clean up any leftover discard confirmation state
+        self._pending_discard_slot.clear()
+        for pid in list(self._pending_actions):
+            if self._pending_actions.get(pid) == "discard_confirm":
+                del self._pending_actions[pid]
+
         player = self.current_player
         if not player or not isinstance(player, MileByMilePlayer):
             return

--- a/server/games/milebymile/game.py
+++ b/server/games/milebymile/game.py
@@ -999,6 +999,7 @@ class MileByMileGame(Game):
         """Show a yes/no confirmation to discard the unplayable card."""
         self._pending_discard_slot[player.id] = slot
         self._pending_actions[player.id] = "discard_confirm"
+        user.speak_l("milebymile-discard-confirm")
         items = [
             MenuItem(text=Localization.get(user.locale, "confirm-yes"), id="yes"),
             MenuItem(text=Localization.get(user.locale, "confirm-no"), id="no"),

--- a/server/locales/en/milebymile.ftl
+++ b/server/locales/en/milebymile.ftl
@@ -45,6 +45,7 @@ milebymile-status = { $name }: { $points } points, { $miles } miles, Problems: {
 milebymile-no-matching-safety = You don't have the matching safety card!
 milebymile-cant-play = You can't play { $card } because { $reason }.
 milebymile-no-card-selected = No card selected to discard.
+milebymile-cant-discard-playable = You can't discard a card that can be played.
 milebymile-no-valid-targets = No valid targets for this hazard!
 milebymile-you-drew = You drew: { $card }
 milebymile-discards = { $player } discards a card.

--- a/server/locales/en/milebymile.ftl
+++ b/server/locales/en/milebymile.ftl
@@ -46,6 +46,7 @@ milebymile-no-matching-safety = You don't have the matching safety card!
 milebymile-cant-play = You can't play { $card } because { $reason }.
 milebymile-no-card-selected = No card selected to discard.
 milebymile-cant-discard-playable = You can't discard a card that can be played.
+milebymile-discard-confirm = Do you want to discard this card?
 milebymile-no-valid-targets = No valid targets for this hazard!
 milebymile-you-drew = You drew: { $card }
 milebymile-discards = { $player } discards a card.

--- a/server/tests/test_milebymile.py
+++ b/server/tests/test_milebymile.py
@@ -195,6 +195,115 @@ class TestMileByMilePlayTest:
         assert game.status == "finished"
 
 
+class TestMileByMileDiscardConfirmation:
+    """Tests for the discard confirmation prompt on tap of an unplayable card."""
+
+    def _setup_unplayable_card(self):
+        """Create a 2-player game where the current player has a STOP hazard
+        and a distance card that therefore cannot be played."""
+        from server.games.milebymile.cards import Card, CardType
+
+        game = MileByMileGame()
+        user1 = MockUser("Alice")
+        user2 = MockUser("Bob")
+        game.add_player("Alice", user1)
+        game.add_player("Bob", user2)
+        game.on_start()
+
+        player = game.current_player
+        race_state = game.get_player_race_state(player)
+        race_state.add_problem(HazardType.STOP)
+
+        distance_card = Card(id=9999, card_type=CardType.DISTANCE, value="25")
+        player.hand = [distance_card]
+        return game, player
+
+    def test_prompts_when_pref_enabled(self):
+        game, player = self._setup_unplayable_card()
+        user = game.get_user(player)
+        user._preferences.confirm_destructive_actions = True
+
+        before_hand_len = len(player.hand)
+        game._action_play_card(player, "card_slot_1")
+
+        # Card is still in hand; a discard_confirm menu was shown.
+        assert len(player.hand) == before_hand_len
+        assert "discard_confirm" in user.menus
+        assert game._pending_actions.get(player.id) == "discard_confirm"
+        assert game._pending_discard_slot.get(player.id) == 0
+
+    def test_discards_immediately_when_pref_disabled(self):
+        game, player = self._setup_unplayable_card()
+        user = game.get_user(player)
+        user._preferences.confirm_destructive_actions = False
+
+        game._action_play_card(player, "card_slot_1")
+
+        # Card was discarded; no confirmation menu was shown.
+        assert len(player.hand) == 0
+        assert "discard_confirm" not in user.menus
+        assert player.id not in game._pending_actions
+
+    def test_per_game_override_disables_prompt(self):
+        game, player = self._setup_unplayable_card()
+        user = game.get_user(player)
+        # Global default is to confirm; override mile by mile specifically.
+        user._preferences.confirm_destructive_actions = True
+        user._preferences.game_overrides["milebymile"] = {
+            "confirm_destructive_actions": False
+        }
+
+        game._action_play_card(player, "card_slot_1")
+
+        assert len(player.hand) == 0
+        assert "discard_confirm" not in user.menus
+
+    def test_yes_confirmation_discards(self):
+        game, player = self._setup_unplayable_card()
+        user = game.get_user(player)
+        user._preferences.confirm_destructive_actions = True
+
+        game._action_play_card(player, "card_slot_1")
+        assert "discard_confirm" in user.menus
+
+        # Respond Yes
+        game._handle_menu_event(
+            player, {"menu_id": "discard_confirm", "selection_id": "yes"}
+        )
+
+        assert len(player.hand) == 0
+        assert player.id not in game._pending_actions
+        assert player.id not in game._pending_discard_slot
+
+    def test_no_confirmation_keeps_card(self):
+        game, player = self._setup_unplayable_card()
+        user = game.get_user(player)
+        user._preferences.confirm_destructive_actions = True
+
+        game._action_play_card(player, "card_slot_1")
+
+        game._handle_menu_event(
+            player, {"menu_id": "discard_confirm", "selection_id": "no"}
+        )
+
+        assert len(player.hand) == 1
+        assert player.id not in game._pending_actions
+        assert player.id not in game._pending_discard_slot
+
+    def test_bot_never_prompts(self):
+        game, player = self._setup_unplayable_card()
+        # Force the current player to be treated as a bot.
+        player.is_bot = True
+
+        game._action_play_card(player, "card_slot_1")
+
+        assert len(player.hand) == 0
+        assert player.id not in game._pending_actions
+
+    def test_relevant_preference_registered(self):
+        assert "confirm_destructive_actions" in MileByMileGame.relevant_preferences
+
+
 class TestMileByMilePersistence:
     """Tests for game persistence."""
 


### PR DESCRIPTION
## Summary

Supersedes / builds on #217. Same bug fix (touch/mobile users had no way to discard unplayable cards because Shift+Enter and Backspace require a physical keyboard), with the yes/no prompt now gated on the user's `confirm_destructive_actions` preference — matching the pattern already used by Pusoy Dos (`server/games/pusoydos/game.py:253`).

- Tapping an **unplayable** card:
  - pref enabled (default) → speak the can't-play reason, show Yes/No discard confirmation.
  - pref disabled (globally or per-game override for Mile by Mile) → speak the reason and discard immediately.
- Playable cards are played as usual — the prompt only appears on unplayable taps.
- Desktop Shift+Enter / Backspace junk keybind still discards directly with no confirmation, so keyboard users keep the existing fast path.
- Bots never prompt.

## Changes from #217

- Added `relevant_preferences = [\"confirm_destructive_actions\"]` to `MileByMileGame`.
- `_action_play_card`: reads `user.preferences.get_effective(\"confirm_destructive_actions\", game_type=self.get_type())` before deciding prompt vs. immediate discard.
- Narrowed the `rebuild_player_menu` override so it only skips rebuild while `discard_confirm` is pending — unrelated pending actions (e.g. hazard target selection) are unaffected.
- Switched `MenuItem` / `EscapeBehavior` import to the relative form used by the rest of the file.
- Added `TestMileByMileDiscardConfirmation` with 7 cases covering pref on/off, per-game override, Yes/No responses, bot skip, and the `relevant_preferences` registration.

Includes #217's original commits unchanged: the touch prompt infrastructure (`_show_discard_confirm`, `_handle_menu_event`/`_handle_discard_confirm` routing, `_pending_discard_slot` map, `_start_turn` cleanup) and the two new locale keys.

## Test plan

- [x] `pytest tests/test_milebymile.py` — 22 pass (15 existing + 7 new).
- [x] `pytest tests/test_preferences.py` — 31 pass.
- [x] `cli.py simulate milebymile --bots 2` completes.
- [x] `cli.py simulate milebymile --bots 2 --test-serialization` completes.
- [ ] Manual: iPhone — pref enabled, tap unplayable card, hear reason + \"Do you want to discard this card?\", Yes discards.
- [ ] Manual: iPhone — pref disabled for Mile by Mile via per-game overrides, tap unplayable card, card is discarded immediately with reason announced.
- [x] Manual: desktop — Shift+Enter and Backspace still discard directly, no prompt.

## Reviewed by Claude

I reviewed #217 before writing this and everything else in that PR looked correct and appropriate: the pending-action tracking, the `_start_turn` cleanup for stale confirmations, the race-check against `always_allow_discarding`, the locale strings, and the bot bypass. The only change worth calling out is that PR #217's `rebuild_player_menu` override skipped rebuild for *any* pending action — this PR narrows it to `discard_confirm` specifically, so hazard target selection (which also uses `_pending_actions`) isn't affected by the override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)