### PR TITLE
Fix update_menu to preserve focus position when selection_id is given

### DIFF
--- a/server/core/users/network_user.py
+++ b/server/core/users/network_user.py
@@ -283,6 +283,11 @@ class NetworkUser(User):
             self._current_menus[menu_id]["items"] = converted_items
             if position is not None:
                 self._current_menus[menu_id]["position"] = position
+            elif selection_id is not None:
+                for i, item in enumerate(items, 1):
+                    if isinstance(item, MenuItem) and item.id == selection_id:
+                        self._current_menus[menu_id]["position"] = i
+                        break
 
         packet: dict[str, Any] = {
             "type": "menu",


### PR DESCRIPTION
## Summary

- When `update_menu` is called with a `selection_id` but no explicit `position`, resolves the ID to a 1-based position and stores it in `_current_menus`
- Ensures that `rebuild_all_menus` (called by `_handle_turn_menu_selection` after every action) restores focus to the correct item rather than snapping back to the last explicit `position=1`

## Why

`_handle_turn_menu_selection` calls `rebuild_all_menus` after every turn menu action. Games like Phase 10 call `update_player_menu(selection_id=...)` to keep focus on a specific item, but without this fix the immediately-following `rebuild_all_menus` would overwrite that with the last stored position (typically 1 from turn start), causing focus to jump to the top of the menu.

## Test plan

- [x] `test_network_user.py` passes (6 tests)
- [x] Verify focus is preserved when toggling cards during Phase 10 lay-down mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)