### PR TITLE
Harden document permissions and visibility

### DIFF
--- a/server/core/documents/browsing.py
+++ b/server/core/documents/browsing.py
@@ -190,17 +190,48 @@ class DocumentBrowsingMixin:
         """Return True if the user is an admin."""
         return user.trust_level.value >= TrustLevel.ADMIN.value
 
+    def _get_user_visible_locales(self, user: NetworkUser, folder_name: str) -> list[str]:
+        """Return document locales the user is allowed to read."""
+        meta = self._documents.get_document_metadata(folder_name)
+        if meta is None:
+            return []
+        if self._is_admin(user):
+            return sorted(meta.get("locales", {}).keys())
+
+        assigned = self._get_user_assigned_languages(user.username)
+        return sorted(
+            locale_code
+            for locale_code, loc_info in meta.get("locales", {}).items()
+            if loc_info.get("public", False) or locale_code in assigned
+        )
+
     def _get_user_assigned_languages(self, username: str) -> set[str]:
         """Return the set of languages assigned to a user as a transcriber."""
         return set(self._db.get_transcriber_languages(username))
 
     def _get_user_accessible_locales(self, user: NetworkUser, folder_name: str) -> list[str]:
-        """Return document locales the user can edit (assigned to them)."""
+        """Return document locales the user can edit (assigned/admin only)."""
         meta = self._documents.get_document_metadata(folder_name)
         if meta is None:
             return []
+        if self._is_admin(user):
+            return sorted(meta.get("locales", {}).keys())
         assigned = self._get_user_assigned_languages(user.username)
         return [loc for loc in meta.get("locales", {}).keys() if loc in assigned]
+
+    def _deny_document_permission(
+        self,
+        user: NetworkUser,
+        *,
+        folder_name: str | None = None,
+        state: dict | None = None,
+    ) -> None:
+        """Speak a permission error and return to the safest document menu."""
+        user.speak_l("documents-no-permission")
+        if folder_name and state is not None:
+            self._show_document_actions(user, folder_name, state)
+        else:
+            self._show_documents_menu(user)
 
     def _get_document_title(self, folder_name: str, locale: str) -> str:
         """Get display title for a document."""
@@ -210,6 +241,57 @@ class DocumentBrowsingMixin:
         titles = meta.get("titles", {})
         return titles.get(locale) or titles.get("en") or folder_name
 
+    def _get_visible_document_title(
+        self,
+        folder_name: str,
+        preferred_locale: str,
+        visible_locales: list[str],
+    ) -> str:
+        """Get a document title without falling back to hidden locales."""
+        meta = self._documents.get_document_metadata(folder_name)
+        if meta is None:
+            return folder_name
+
+        titles = meta.get("titles", {})
+        source_locale = meta.get("source_locale", "en")
+        ordered_locales: list[str] = []
+        for locale_code in [preferred_locale, source_locale, "en", *visible_locales]:
+            if locale_code in visible_locales and locale_code not in ordered_locales:
+                ordered_locales.append(locale_code)
+
+        for locale_code in ordered_locales:
+            title = titles.get(locale_code)
+            if title:
+                return title
+        return folder_name
+
+    def _get_title_candidate_locales(
+        self, user: NetworkUser, folder_name: str, meta: dict | None = None
+    ) -> list[str]:
+        """Return locales this user may target for title edits."""
+        if self._is_admin(user):
+            return sorted(Localization.get_available_locale_codes())
+
+        assigned = self._get_user_assigned_languages(user.username)
+        return [
+            code
+            for code in Localization.get_available_locale_codes()
+            if code in assigned
+        ]
+
+    def _get_add_translation_locales(
+        self, user: NetworkUser, folder_name: str, meta: dict | None = None
+    ) -> list[str]:
+        """Return locales this user may add as new translations."""
+        if meta is None:
+            return []
+        existing_locales = set(meta.get("locales", {}).keys())
+        if self._is_admin(user):
+            candidates = Localization.get_available_locale_codes()
+        else:
+            candidates = sorted(self._get_user_assigned_languages(user.username))
+        return [code for code in candidates if code not in existing_locales]
+
     # ------------------------------------------------------------------
     # Category / document list browsing
     # ------------------------------------------------------------------
@@ -217,8 +299,11 @@ class DocumentBrowsingMixin:
     def _show_documents_menu(self, user: NetworkUser) -> None:
         """Show the documents category menu."""
         categories = self._documents.get_categories(user.locale)
-        counts = self._documents.get_category_document_counts()
         is_admin = self._is_admin(user)
+        counts = self._documents.get_category_document_counts(
+            include_private=is_admin,
+            allowed_private_locales=self._get_user_assigned_languages(user.username),
+        )
         show_empty = is_admin or self._is_transcriber(user.username)
 
         items = []
@@ -321,16 +406,34 @@ class DocumentBrowsingMixin:
         elif selection_id == "uncategorized":
             self._show_documents_list(user, "")
         elif selection_id == "new_document":
+            if not self._is_admin(user):
+                self._deny_document_permission(user)
+                return
             self._show_new_document_scope(user)
         elif selection_id == "new_category":
+            if not self._is_admin(user):
+                self._deny_document_permission(user)
+                return
             self._show_new_category_slug_editbox(user)
         elif selection_id == "sync_documents":
+            if not self._is_admin(user):
+                self._deny_document_permission(user)
+                return
             await self._handle_sync_documents(user)
         elif selection_id == "export_pending":
+            if not self._is_admin(user):
+                self._deny_document_permission(user)
+                return
             await self._handle_export_pending(user)
         elif selection_id == "create_pr":
+            if not self._is_admin(user):
+                self._deny_document_permission(user)
+                return
             await self._handle_create_pr(user)
         elif selection_id == "pending_info":
+            if not self._is_admin(user):
+                self._deny_document_permission(user)
+                return
             self._handle_pending_info(user)
         elif selection_id == "transcribers_by_language":
             self._show_transcribers_by_language(user)
@@ -541,7 +644,12 @@ class DocumentBrowsingMixin:
 
     def _show_documents_list(self, user: NetworkUser, category_slug: str | None) -> None:
         """Show the list of documents in a category."""
-        documents = self._documents.get_documents_in_category(category_slug, user.locale)
+        documents = self._documents.get_documents_in_category(
+            category_slug,
+            user.locale,
+            include_private=self._is_admin(user),
+            allowed_private_locales=self._get_user_assigned_languages(user.username),
+        )
         is_real_category = category_slug is not None and category_slug != ""
         is_admin = self._is_admin(user)
         is_transcriber = self._is_transcriber(user.username)
@@ -595,10 +703,19 @@ class DocumentBrowsingMixin:
         if selection_id == "back":
             self._show_documents_menu(user)
         elif selection_id == "rename_category":
+            if not (self._is_transcriber(user.username) or self._is_admin(user)):
+                self._deny_document_permission(user)
+                return
             self._show_rename_category_editbox(user, category_slug)
         elif selection_id == "category_settings":
+            if not self._is_admin(user):
+                self._deny_document_permission(user)
+                return
             self._show_category_settings(user, category_slug)
         elif selection_id == "delete_category":
+            if not self._is_admin(user):
+                self._deny_document_permission(user)
+                return
             self._show_delete_category_confirm(user, category_slug)
         elif selection_id.startswith("doc_"):
             folder_name = selection_id[4:]
@@ -613,14 +730,36 @@ class DocumentBrowsingMixin:
 
     def _show_document_view(self, user: NetworkUser, folder_name: str, state: dict) -> None:
         """Show a document in a read-only editbox."""
-        content = self._documents.get_document_content(folder_name, user.locale)
-        if content is None:
-            content = self._documents.get_document_content(folder_name, "en")
+        visible_locales = self._get_user_visible_locales(user, folder_name)
+        allowed_private_locales = self._get_user_assigned_languages(user.username)
+        meta = self._documents.get_document_metadata(folder_name) or {}
+        source_locale = meta.get("source_locale", "en")
+        title_locale = None
+        content = None
+        for locale_code in [user.locale, "en", source_locale, *visible_locales]:
+            if locale_code not in visible_locales or locale_code == title_locale:
+                continue
+            candidate_content = self._documents.get_document_content_for_access(
+                folder_name,
+                locale_code,
+                include_private=self._is_admin(user),
+                allowed_private_locales=allowed_private_locales,
+            )
+            if candidate_content is None:
+                continue
+            content = candidate_content
+            title_locale = locale_code
+            break
         if content is None:
             user.speak_l("documents-no-content")
+            self._show_documents_list(user, state.get("category_slug"))
             return
 
-        title = self._get_document_title(folder_name, user.locale)
+        title = self._get_visible_document_title(
+            folder_name,
+            title_locale or user.locale,
+            visible_locales,
+        )
 
         user.show_editbox(
             "document_view",
@@ -790,18 +929,39 @@ class DocumentBrowsingMixin:
         if selection_id == "back":
             self._show_document_actions(user, folder_name, state)
         elif selection_id == "change_title":
+            if not (self._is_admin(user) or self._is_transcriber(user.username)):
+                self._deny_document_permission(user, folder_name=folder_name, state=state)
+                return
             self._show_document_title_languages(user, folder_name, state)
         elif selection_id == "manage_visibility":
+            if not (self._is_admin(user) or self._is_transcriber(user.username)):
+                self._deny_document_permission(user, folder_name=folder_name, state=state)
+                return
             self._show_document_visibility(user, folder_name, state)
         elif selection_id == "modify_categories":
+            if not self._is_admin(user):
+                self._deny_document_permission(user, folder_name=folder_name, state=state)
+                return
             self._show_document_categories(user, folder_name, state)
         elif selection_id == "add_translation":
+            if not (self._is_admin(user) or self._is_transcriber(user.username)):
+                self._deny_document_permission(user, folder_name=folder_name, state=state)
+                return
             self._show_add_translation_languages(user, folder_name, state)
         elif selection_id == "remove_translation":
+            if not self._is_admin(user):
+                self._deny_document_permission(user, folder_name=folder_name, state=state)
+                return
             self._show_remove_translation_languages(user, folder_name, state)
         elif selection_id == "delete_document":
+            if not self._is_admin(user):
+                self._deny_document_permission(user, folder_name=folder_name, state=state)
+                return
             self._show_delete_document_confirm(user, folder_name, state)
         elif selection_id == "promote_to_shared":
+            if not self._is_admin(user):
+                self._deny_document_permission(user, folder_name=folder_name, state=state)
+                return
             self._show_promote_confirm(user, folder_name, state)
         elif selection_id == "based_on_stale_notice":
             # Informational item — just refresh the settings menu
@@ -824,6 +984,9 @@ class DocumentBrowsingMixin:
     ) -> None:
         """Handle promote-to-shared confirmation."""
         folder_name = state.get("folder_name", "")
+        if not self._is_admin(user):
+            self._deny_document_permission(user, folder_name=folder_name, state=state)
+            return
         if selection_id == "yes":
             result = self._documents.promote_to_shared(folder_name)
             if result:
@@ -858,11 +1021,8 @@ class DocumentBrowsingMixin:
             self._show_document_settings(user, folder_name, state)
             return
 
-        # Show all available locales (titles are transcribable even without
-        # an existing translation), filtered to assigned languages.
-        assigned = self._get_user_assigned_languages(user.username)
-        all_codes = Localization.get_available_locale_codes()
-        title_locales = [code for code in all_codes if code in assigned]
+        # Titles are transcribable even without an existing translation.
+        title_locales = self._get_title_candidate_locales(user, folder_name, meta)
 
         if not title_locales:
             user.speak_l("documents-no-permission")
@@ -1033,8 +1193,8 @@ class DocumentBrowsingMixin:
         elif selection_id.startswith("lang_"):
             locale_code = selection_id[5:]
             # Permission check: user must have this language assigned
-            assigned = set(self._db.get_transcriber_languages(user.username))
-            if locale_code not in assigned:
+            assigned = self._get_user_assigned_languages(user.username)
+            if not self._is_admin(user) and locale_code not in assigned:
                 lang_name = Localization.get(user.locale, f"language-{locale_code}")
                 user.speak_l("documents-visibility-no-permission", language=lang_name)
                 self._show_document_visibility(user, folder_name, state, focus_locale=locale_code)
@@ -1112,6 +1272,9 @@ class DocumentBrowsingMixin:
         if selection_id == "back":
             self._show_document_settings(user, folder_name, state)
         elif selection_id.startswith("cat_"):
+            if not self._is_admin(user):
+                self._deny_document_permission(user, folder_name=folder_name, state=state)
+                return
             slug = selection_id[4:]
             meta = self._documents.get_document_metadata(folder_name)
             if meta:
@@ -1211,6 +1374,9 @@ class DocumentBrowsingMixin:
         """Handle remove-translation confirmation."""
         folder_name = state.get("folder_name", "")
         locale_code = state.get("locale_code", "")
+        if not self._is_admin(user):
+            self._deny_document_permission(user, folder_name=folder_name, state=state)
+            return
         if selection_id == "yes":
             lock_holder = self._documents.get_edit_lock_holder(
                 folder_name,
@@ -1284,6 +1450,9 @@ class DocumentBrowsingMixin:
         """Handle title removal confirmation after translation removal."""
         folder_name = state.get("folder_name", "")
         locale_code = state.get("locale_code", "")
+        if not self._is_admin(user):
+            self._deny_document_permission(user, folder_name=folder_name, state=state)
+            return
         remove_title = selection_id == "yes"
         self._documents.remove_document_translation(
             folder_name,
@@ -1302,16 +1471,6 @@ class DocumentBrowsingMixin:
         self, user: NetworkUser, folder_name: str, state: dict
     ) -> None:
         """Show yes/no confirmation for deleting a document."""
-
-        # Require at least one assigned language matching the document
-        meta = self._documents.get_document_metadata(folder_name)
-        if meta:
-            doc_locale_codes = set(meta.get("locales", {}).keys())
-            assigned = set(self._db.get_transcriber_languages(user.username))
-            if not doc_locale_codes & assigned:
-                user.speak_l("documents-no-permission")
-                self._show_document_settings(user, folder_name, state)
-                return
 
         count = self._documents.get_document_locale_count(folder_name)
         question = Localization.get(
@@ -1332,6 +1491,9 @@ class DocumentBrowsingMixin:
         """Handle delete-document confirmation."""
         folder_name = state.get("folder_name", "")
         category_slug = state.get("category_slug")
+        if not self._is_admin(user):
+            self._deny_document_permission(user)
+            return
         if selection_id == "yes":
             active_locks = self._documents.get_document_lock_holders(
                 folder_name,
@@ -1400,6 +1562,9 @@ class DocumentBrowsingMixin:
             self._show_document_actions(user, folder_name, state)
         elif selection_id.startswith("lang_"):
             locale_code = selection_id[5:]
+            if locale_code not in self._get_user_accessible_locales(user, folder_name):
+                self._deny_document_permission(user, folder_name=folder_name, state=state)
+                return
             self._open_document_editor(
                 user,
                 folder_name,
@@ -1421,12 +1586,7 @@ class DocumentBrowsingMixin:
             self._show_document_settings(user, folder_name, state)
             return
 
-        existing_locales = set(meta.get("locales", {}).keys())
-        assigned = self._get_user_assigned_languages(user.username)
-        all_codes = Localization.get_available_locale_codes()
-        available = [
-            code for code in all_codes if code in assigned and code not in existing_locales
-        ]
+        available = self._get_add_translation_locales(user, folder_name, meta)
 
         if not available:
             user.speak_l("documents-no-languages-available")
@@ -1463,6 +1623,10 @@ class DocumentBrowsingMixin:
             self._show_document_settings(user, folder_name, state)
         elif selection_id.startswith("lang_"):
             locale_code = selection_id[5:]
+            assigned = self._get_user_assigned_languages(user.username)
+            if not self._is_admin(user) and locale_code not in assigned:
+                self._deny_document_permission(user, folder_name=folder_name, state=state)
+                return
             # Show title editbox for the new translation, pre-populated
             # with existing title if one was set (e.g. via change-title).
             lang_name = Localization.get(user.locale, f"language-{locale_code}")
@@ -1789,6 +1953,9 @@ class DocumentBrowsingMixin:
 
     def _show_new_document_scope(self, user: NetworkUser) -> None:
         """Show scope selection menu for a new document."""
+        if not self._is_admin(user):
+            self._deny_document_permission(user)
+            return
         items = [
             MenuItem(
                 text=Localization.get(user.locale, "documents-scope-shared"),
@@ -1816,6 +1983,9 @@ class DocumentBrowsingMixin:
         self, user: NetworkUser, selection_id: str, state: dict
     ) -> None:
         """Handle scope selection for new document creation."""
+        if not self._is_admin(user):
+            self._deny_document_permission(user)
+            return
         if selection_id == "back":
             self._show_documents_menu(user)
             return
@@ -1891,6 +2061,9 @@ class DocumentBrowsingMixin:
         self, user: NetworkUser, selection_id: str, state: dict
     ) -> None:
         """Handle category toggle/done/back for new document creation."""
+        if not self._is_admin(user):
+            self._deny_document_permission(user)
+            return
         if selection_id == "back":
             self._show_documents_menu(user)
         elif selection_id == "done":
@@ -1923,6 +2096,9 @@ class DocumentBrowsingMixin:
 
     def _handle_new_document_slug(self, user: NetworkUser, value: str, state: dict) -> None:
         """Handle slug editbox submission for a new document."""
+        if not self._is_admin(user):
+            self._deny_document_permission(user)
+            return
         if not value.strip():
             self._show_documents_menu(user)
             return
@@ -1972,6 +2148,9 @@ class DocumentBrowsingMixin:
 
     def _handle_new_category_slug(self, user: NetworkUser, value: str, state: dict) -> None:
         """Handle slug editbox submission for a new category."""
+        if not self._is_admin(user):
+            self._deny_document_permission(user)
+            return
         if not value.strip():
             self._show_documents_menu(user)
             return
@@ -2006,6 +2185,9 @@ class DocumentBrowsingMixin:
 
     def _handle_new_category_name(self, user: NetworkUser, value: str, state: dict) -> None:
         """Handle name editbox submission for a new category."""
+        if not self._is_admin(user):
+            self._deny_document_permission(user)
+            return
         slug = state.get("category_slug", "")
         if not value.strip():
             self._show_documents_menu(user)
@@ -2052,6 +2234,9 @@ class DocumentBrowsingMixin:
 
     def _handle_rename_category(self, user: NetworkUser, value: str, state: dict) -> None:
         """Handle rename editbox submission for a category."""
+        if not (self._is_transcriber(user.username) or self._is_admin(user)):
+            self._deny_document_permission(user)
+            return
         slug = state.get("category_slug", "")
         if not value.strip():
             self._show_documents_list(user, slug)
@@ -2102,6 +2287,9 @@ class DocumentBrowsingMixin:
         self, user: NetworkUser, selection_id: str, state: dict
     ) -> None:
         """Handle category settings submenu selection."""
+        if not self._is_admin(user):
+            self._deny_document_permission(user)
+            return
         category_slug = state.get("category_slug", "")
         if selection_id == "back":
             self._show_documents_list(user, category_slug)
@@ -2145,6 +2333,9 @@ class DocumentBrowsingMixin:
         self, user: NetworkUser, selection_id: str, state: dict
     ) -> None:
         """Handle sort method selection."""
+        if not self._is_admin(user):
+            self._deny_document_permission(user)
+            return
         category_slug = state.get("category_slug", "")
         if selection_id == "back":
             self._show_category_settings(user, category_slug)
@@ -2173,6 +2364,9 @@ class DocumentBrowsingMixin:
         self, user: NetworkUser, selection_id: str, state: dict
     ) -> None:
         """Handle delete-category confirmation."""
+        if not self._is_admin(user):
+            self._deny_document_permission(user)
+            return
         category_slug = state.get("category_slug", "")
         if selection_id == "yes":
             self._documents.delete_category(category_slug)

--- a/server/core/documents/manager.py
+++ b/server/core/documents/manager.py
@@ -190,14 +190,28 @@ class DocumentManager:
         result.sort(key=lambda c: c["name"].lower())
         return result
 
-    def get_category_document_counts(self) -> dict[str | None, int]:
+    def get_category_document_counts(
+        self,
+        *,
+        include_private: bool = True,
+        allowed_private_locales: set[str] | None = None,
+    ) -> dict[str | None, int]:
         """Return document counts per category in a single pass.
 
         Keys are category slugs, plus ``None`` for all documents and
         ``""`` for uncategorized.
         """
-        counts: dict[str | None, int] = {None: len(self._documents), "": 0}
+        counts: dict[str | None, int] = {None: 0, "": 0}
         for meta in self._documents.values():
+            visible_locales = self._get_visible_locale_codes(
+                meta,
+                include_private=include_private,
+                allowed_private_locales=allowed_private_locales,
+            )
+            if not visible_locales:
+                continue
+
+            counts[None] += 1
             cats = meta.get("categories", [])
             if not cats:
                 counts[""] += 1
@@ -205,13 +219,84 @@ class DocumentManager:
                 counts[slug] = counts.get(slug, 0) + 1
         return counts
 
-    def get_documents_in_category(self, category_slug: str | None, locale: str) -> list[dict]:
+    @staticmethod
+    def _get_visible_locale_codes(
+        meta: dict,
+        *,
+        include_private: bool,
+        allowed_private_locales: set[str] | None = None,
+    ) -> list[str]:
+        """Return locale codes visible to the current caller."""
+        locales = meta.get("locales", {})
+        if include_private:
+            return list(locales.keys())
+
+        allowed_private_locales = allowed_private_locales or set()
+        return [
+            locale_code
+            for locale_code, locale_meta in locales.items()
+            if locale_meta.get("public", False) or locale_code in allowed_private_locales
+        ]
+
+    @staticmethod
+    def _select_display_title_locale(
+        visible_locales: list[str],
+        preferred_locale: str,
+        source_locale: str,
+    ) -> str | None:
+        """Pick the best locale to display from the visible locales."""
+        if preferred_locale in visible_locales:
+            return preferred_locale
+        if source_locale in visible_locales:
+            return source_locale
+        if "en" in visible_locales:
+            return "en"
+        if visible_locales:
+            return sorted(visible_locales)[0]
+        return None
+
+    @staticmethod
+    def _select_visible_title(
+        titles: dict[str, str],
+        visible_locales: list[str],
+        preferred_locale: str,
+        source_locale: str,
+        folder_name: str,
+    ) -> str:
+        """Pick the best available title without using hidden locales."""
+        ordered_locales: list[str] = []
+        for locale_code in [
+            preferred_locale,
+            source_locale,
+            "en",
+            *sorted(visible_locales),
+        ]:
+            if locale_code in visible_locales and locale_code not in ordered_locales:
+                ordered_locales.append(locale_code)
+
+        for locale_code in ordered_locales:
+            title = titles.get(locale_code)
+            if title:
+                return title
+        return folder_name
+
+    def get_documents_in_category(
+        self,
+        category_slug: str | None,
+        locale: str,
+        *,
+        include_private: bool = True,
+        allowed_private_locales: set[str] | None = None,
+    ) -> list[dict]:
         """Return documents in a category.
 
         Args:
             category_slug: Category slug to filter by.  ``None`` returns all
                 documents, ``""`` returns uncategorized documents.
             locale: Locale for display title resolution.
+            include_private: When ``True``, include private locales.
+            allowed_private_locales: Private locales still visible when
+                ``include_private`` is ``False``.
 
         Returns a list of dicts with ``folder_name`` and ``title``.
         """
@@ -227,11 +312,28 @@ class DocumentManager:
                 if category_slug not in cats:
                     continue
 
+            visible_locales = self._get_visible_locale_codes(
+                meta,
+                include_private=include_private,
+                allowed_private_locales=allowed_private_locales,
+            )
+            if not visible_locales:
+                continue
+
             titles = meta.get("titles", {})
-            title = titles.get(locale) or titles.get("en") or folder_name
-            # Include sort-relevant timestamps from source locale.
             source = meta.get("source_locale", "en")
-            loc_info = meta.get("locales", {}).get(source, {})
+            title_locale = self._select_display_title_locale(visible_locales, locale, source)
+            title = self._select_visible_title(
+                titles,
+                visible_locales,
+                title_locale or locale,
+                source,
+                folder_name,
+            )
+
+            # Include sort-relevant timestamps from a visible locale.
+            timestamp_locale = source if source in visible_locales else title_locale
+            loc_info = meta.get("locales", {}).get(timestamp_locale or "", {})
             results.append(
                 {
                     "folder_name": folder_name,
@@ -269,6 +371,10 @@ class DocumentManager:
         """Read a document's ``.md`` file for the given locale."""
         if folder_name not in self._documents:
             return None
+        meta = self._documents[folder_name]
+        visible_locales = self._get_visible_locale_codes(meta, include_private=True)
+        if locale not in visible_locales:
+            return None
         doc_dir = self._document_dir(folder_name)
         if doc_dir is None:
             return None
@@ -276,6 +382,27 @@ class DocumentManager:
         if not md_path.exists():
             return None
         return md_path.read_text(encoding="utf-8")
+
+    def get_document_content_for_access(
+        self,
+        folder_name: str,
+        locale: str,
+        *,
+        include_private: bool = True,
+        allowed_private_locales: set[str] | None = None,
+    ) -> str | None:
+        """Read document content only if the locale is visible to the caller."""
+        meta = self._documents.get(folder_name)
+        if meta is None:
+            return None
+        visible_locales = self._get_visible_locale_codes(
+            meta,
+            include_private=include_private,
+            allowed_private_locales=allowed_private_locales,
+        )
+        if locale not in visible_locales:
+            return None
+        return self.get_document_content(folder_name, locale)
 
     # ------------------------------------------------------------------
     # Writing

--- a/server/core/documents/transcriber_role.py
+++ b/server/core/documents/transcriber_role.py
@@ -22,6 +22,11 @@ class TranscriberRoleMixin:
     _db: "Database"
     _user_states: dict[str, dict]
 
+    def _transcriber_admin_denied(self, user: NetworkUser) -> None:
+        """Reject a transcriber-management action for non-admins."""
+        user.speak_l("documents-no-permission")
+        self._show_documents_menu(user)
+
     def _get_transcriber_menu_handlers(
         self, user: "NetworkUser", selection_id: str, state: dict
     ) -> dict[str, tuple]:
@@ -152,6 +157,9 @@ class TranscriberRoleMixin:
         if selection_id == "back":
             self._show_transcribers_by_language(user)
         elif selection_id == "add_users":
+            if user.trust_level.value < TrustLevel.ADMIN.value:
+                self._transcriber_admin_denied(user)
+                return
             self._show_add_transcriber_users(user, lang_code)
         elif selection_id.startswith("user_"):
             target_username = selection_id[5:]
@@ -186,6 +194,9 @@ class TranscriberRoleMixin:
         """Handle transcriber removal confirmation."""
         lang_code = state.get("lang_code", "")
         target_username = state.get("target_username", "")
+        if user.trust_level.value < TrustLevel.ADMIN.value:
+            self._transcriber_admin_denied(user)
+            return
         if selection_id == "yes":
             self._db.remove_transcriber_assignment(target_username, lang_code)
             lang_name = Localization.get(user.locale, f"language-{lang_code}")
@@ -255,6 +266,9 @@ class TranscriberRoleMixin:
         """Handle selection in the add-transcriber-users menu."""
         lang_code = state.get("lang_code", "")
         enabled_users: set[str] = state.get("enabled_users", set())
+        if user.trust_level.value < TrustLevel.ADMIN.value:
+            self._transcriber_admin_denied(user)
+            return
         if selection_id == "done":
             if enabled_users:
                 lang_name = Localization.get(user.locale, f"language-{lang_code}")
@@ -325,6 +339,9 @@ class TranscriberRoleMixin:
         if selection_id == "back":
             self._show_documents_menu(user)
         elif selection_id == "add_user":
+            if user.trust_level.value < TrustLevel.ADMIN.value:
+                self._transcriber_admin_denied(user)
+                return
             self._show_add_transcriber_user_picker(user)
         elif selection_id.startswith("user_"):
             target_username = selection_id[5:]
@@ -361,6 +378,9 @@ class TranscriberRoleMixin:
         self, user: NetworkUser, selection_id: str, state: dict
     ) -> None:
         """Handle selection in the add-transcriber user picker."""
+        if user.trust_level.value < TrustLevel.ADMIN.value:
+            self._transcriber_admin_denied(user)
+            return
         if selection_id == "back":
             self._show_transcribers_by_user(user)
         elif selection_id.startswith("pick_"):
@@ -418,8 +438,14 @@ class TranscriberRoleMixin:
         if selection_id == "back":
             self._show_transcribers_by_user(user)
         elif selection_id == "add_languages":
+            if user.trust_level.value < TrustLevel.ADMIN.value:
+                self._transcriber_admin_denied(user)
+                return
             self._show_add_transcriber_languages(user, target_username)
         elif selection_id == "remove_transcriber":
+            if user.trust_level.value < TrustLevel.ADMIN.value:
+                self._transcriber_admin_denied(user)
+                return
             self._show_transcriber_remove_all_confirm(user, target_username)
         elif selection_id.startswith("lang_"):
             lang_code = selection_id[5:]
@@ -454,6 +480,9 @@ class TranscriberRoleMixin:
         """Handle language removal confirmation."""
         target_username = state.get("target_username", "")
         lang_code = state.get("lang_code", "")
+        if user.trust_level.value < TrustLevel.ADMIN.value:
+            self._transcriber_admin_denied(user)
+            return
         if selection_id == "yes":
             self._db.remove_transcriber_assignment(target_username, lang_code)
             lang_name = Localization.get(user.locale, f"language-{lang_code}")
@@ -484,6 +513,9 @@ class TranscriberRoleMixin:
     ) -> None:
         """Handle removal of all transcriber assignments."""
         target_username = state.get("target_username", "")
+        if user.trust_level.value < TrustLevel.ADMIN.value:
+            self._transcriber_admin_denied(user)
+            return
         if selection_id == "yes":
             lang_codes = self._db.get_transcriber_languages(target_username)
             for lang_code in lang_codes:

--- a/server/core/server.py
+++ b/server/core/server.py
@@ -2123,6 +2123,17 @@ class Server(AdministrationMixin, DocumentBrowsingMixin, TranscriberRoleMixin):
                     self._show_main_menu(user, reset_history=True)
             return
 
+        if not self._selection_allowed_for_current_menu(user, current_menu, selection_id):
+            LOG.warning(
+                "Rejected invalid menu selection",
+                extra={
+                    "username": user.username,
+                    "menu": current_menu,
+                    "selection_id": selection_id,
+                },
+            )
+            return
+
         await self._dispatch_menu_selection(user, selection_id, state, current_menu)
         self._prune_menu_history_after_dispatch(
             user=user,
@@ -2180,6 +2191,41 @@ class Server(AdministrationMixin, DocumentBrowsingMixin, TranscriberRoleMixin):
             if isinstance(item, dict) and item.get("id") == selection_id:
                 menu_state["position"] = index
                 return
+
+    def _selection_allowed_for_current_menu(
+        self,
+        user: NetworkUser,
+        current_menu: str | None,
+        selection_id: str,
+    ) -> bool:
+        """Return whether a selection belongs to the user's currently shown menu."""
+        if not current_menu or not selection_id:
+            return True
+
+        current_menus = getattr(user, "_current_menus", None)
+        if not isinstance(current_menus, dict):
+            return True
+
+        menu_state = current_menus.get(current_menu)
+        if not isinstance(menu_state, dict):
+            return True
+
+        items = menu_state.get("items")
+        if not isinstance(items, list):
+            return True
+
+        allowed_ids: set[str] = set()
+        for item in items:
+            if isinstance(item, dict):
+                item_id = item.get("id")
+                if isinstance(item_id, str) and item_id:
+                    allowed_ids.add(item_id)
+            elif isinstance(item, str) and item:
+                allowed_ids.add(item)
+
+        if not allowed_ids:
+            return True
+        return selection_id in allowed_ids
 
     async def _dispatch_menu_selection(
         self,

--- a/server/tests/test_document_manager.py
+++ b/server/tests/test_document_manager.py
@@ -306,6 +306,146 @@ class TestGetDocumentsInCategory:
         names = {d["folder_name"] for d in docs}
         assert names == {"shared_doc", "indie_doc"}
 
+    def test_private_documents_are_hidden_without_access(self, manager, docs_dir):
+        _create_doc_on_disk(
+            docs_dir,
+            "private_doc",
+            meta_override={
+                "categories": [],
+                "source_locale": "fr",
+                "titles": {"fr": "Document prive"},
+                "locales": {
+                    "fr": {
+                        "created": "2026-01-01T00:00:00Z",
+                        "modified_contents": "2026-01-01T00:00:00Z",
+                        "public": False,
+                    }
+                },
+            },
+        )
+        manager.load()
+
+        docs = manager.get_documents_in_category(None, "fr", include_private=False)
+
+        assert docs == []
+
+    def test_assigned_private_locale_remains_visible_in_listings(self, manager, docs_dir):
+        _create_doc_on_disk(
+            docs_dir,
+            "translator_doc",
+            locale="fr",
+            meta_override={
+                "categories": [],
+                "source_locale": "fr",
+                "titles": {"fr": "Document prive"},
+                "locales": {
+                    "fr": {
+                        "created": "2026-01-01T00:00:00Z",
+                        "modified_contents": "2026-01-01T00:00:00Z",
+                        "public": False,
+                    }
+                },
+            },
+        )
+        manager.load()
+
+        docs = manager.get_documents_in_category(
+            None,
+            "fr",
+            include_private=False,
+            allowed_private_locales={"fr"},
+        )
+
+        assert [doc["folder_name"] for doc in docs] == ["translator_doc"]
+
+    def test_listing_falls_back_to_other_visible_title(self, manager, docs_dir):
+        _create_doc_on_disk(
+            docs_dir,
+            "partially_translated_doc",
+            locale="fr",
+            meta_override={
+                "categories": [],
+                "source_locale": "en",
+                "titles": {"en": "English Title"},
+                "locales": {
+                    "en": {
+                        "created": "2026-01-01T00:00:00Z",
+                        "modified_contents": "2026-01-01T00:00:00Z",
+                        "public": True,
+                    },
+                    "fr": {
+                        "created": "2026-01-01T00:00:00Z",
+                        "modified_contents": "2026-01-01T00:00:00Z",
+                        "public": False,
+                    },
+                },
+            },
+        )
+        manager.load()
+
+        docs = manager.get_documents_in_category(
+            None,
+            "fr",
+            include_private=False,
+            allowed_private_locales={"fr"},
+        )
+
+        assert len(docs) == 1
+        assert docs[0]["title"] == "English Title"
+
+
+class TestGetCategoryDocumentCounts:
+    def test_hidden_private_documents_are_excluded_from_counts(self, manager, docs_dir):
+        _create_doc_on_disk(
+            docs_dir,
+            "hidden_doc",
+            meta_override={
+                "categories": ["rules"],
+                "source_locale": "en",
+                "titles": {"en": "Hidden Doc"},
+                "locales": {
+                    "en": {
+                        "created": "2026-01-01T00:00:00Z",
+                        "modified_contents": "2026-01-01T00:00:00Z",
+                        "public": False,
+                    }
+                },
+            },
+        )
+        manager.load()
+
+        counts = manager.get_category_document_counts(include_private=False)
+
+        assert counts == {None: 0, "": 0}
+
+    def test_allowed_private_locales_still_count_documents(self, manager, docs_dir):
+        _create_doc_on_disk(
+            docs_dir,
+            "translator_doc",
+            locale="fr",
+            meta_override={
+                "categories": ["rules"],
+                "source_locale": "fr",
+                "titles": {"fr": "Translator Doc"},
+                "locales": {
+                    "fr": {
+                        "created": "2026-01-01T00:00:00Z",
+                        "modified_contents": "2026-01-01T00:00:00Z",
+                        "public": False,
+                    }
+                },
+            },
+        )
+        manager.load()
+
+        counts = manager.get_category_document_counts(
+            include_private=False,
+            allowed_private_locales={"fr"},
+        )
+
+        assert counts[None] == 1
+        assert counts["rules"] == 1
+
 
 # ------------------------------------------------------------------
 # get_document_content
@@ -329,6 +469,40 @@ class TestGetDocumentContent:
     def test_returns_none_for_missing_document(self, manager):
         manager.load()
         assert manager.get_document_content("nonexistent", "en") is None
+
+    def test_private_locale_requires_explicit_access(self, manager, docs_dir):
+        _create_doc_on_disk(
+            docs_dir,
+            "hello",
+            locale="fr",
+            content="bonjour",
+            meta_override={
+                "categories": [],
+                "source_locale": "fr",
+                "titles": {"fr": "Bonjour"},
+                "locales": {
+                    "fr": {
+                        "created": "2026-01-01T00:00:00Z",
+                        "modified_contents": "2026-01-01T00:00:00Z",
+                        "public": False,
+                    }
+                },
+            },
+        )
+        manager.load()
+
+        assert manager.get_document_content_for_access(
+            "hello", "fr", include_private=False
+        ) is None
+        assert (
+            manager.get_document_content_for_access(
+                "hello",
+                "fr",
+                include_private=False,
+                allowed_private_locales={"fr"},
+            )
+            == "bonjour"
+        )
 
 
 # ------------------------------------------------------------------

--- a/server/tests/test_server_documents_security.py
+++ b/server/tests/test_server_documents_security.py
@@ -1,0 +1,337 @@
+"""Security tests for document and transcriber authorization."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from server.core.documents.manager import DocumentManager
+from server.core.server import Server
+from server.core.users.base import MenuItem, TrustLevel
+from server.core.users.network_user import NetworkUser
+
+
+class DummyConnection:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, payload):
+        self.sent.append(payload)
+
+
+class DummyClient:
+    def __init__(self, username: str):
+        self.username = username
+
+
+def make_user(name: str, *, trust: TrustLevel = TrustLevel.USER, locale: str = "en") -> NetworkUser:
+    user = NetworkUser(name, locale, DummyConnection(), approved=True)
+    user.set_trust_level(trust)
+    user.set_approved(True)
+    return user
+
+
+@pytest.fixture
+def documents_dir(tmp_path):
+    docs = tmp_path / "documents"
+    docs.mkdir()
+    return docs
+
+
+@pytest.fixture
+def server(tmp_path, documents_dir):
+    srv = Server(
+        db_path=str(tmp_path / "security.db"),
+        locales_dir="locales",
+        config_path=tmp_path / "missing.toml",
+    )
+    srv._documents = DocumentManager(documents_dir)
+    srv._documents.load()
+    return srv
+
+
+def last_spoken(user: NetworkUser) -> str:
+    for message in reversed(user.get_queued_messages()):
+        if message["type"] == "speak":
+            return message["text"]
+    return ""
+
+
+def assert_permission_denied(user: NetworkUser) -> None:
+    message = last_spoken(user).lower()
+    assert "assigned languages" in message or "permission" in message
+
+
+def write_document(documents_dir, folder_name: str, metadata: str, files: dict[str, str]) -> None:
+    doc_dir = documents_dir / "shared" / folder_name
+    doc_dir.mkdir(parents=True, exist_ok=True)
+    for locale_code, content in files.items():
+        (doc_dir / f"{locale_code}.md").write_text(content, encoding="utf-8")
+    (doc_dir / "_metadata.json").write_text(metadata, encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_non_admin_cannot_open_new_document_flow(server):
+    user = make_user("player")
+    server._db = SimpleNamespace(get_transcriber_languages=lambda username: [])
+
+    await server._handle_documents_menu_selection(user, "new_document", {})
+
+    assert server._user_states[user.username]["menu"] == "documents_menu"
+    assert_permission_denied(user)
+
+
+@pytest.mark.asyncio
+async def test_non_admin_cannot_open_delete_document_confirm(server, documents_dir):
+    user = make_user("player")
+    write_document(
+        documents_dir,
+        "private_doc",
+        (
+            '{"categories": [], "source_locale": "en", "titles": {"en": "Private Doc"}, '
+            '"locales": {"en": {"created": "2026-01-01T00:00:00Z", '
+            '"modified_contents": "2026-01-01T00:00:00Z", "public": true}}}'
+        ),
+        {"en": "hello"},
+    )
+    server._documents.load()
+    server._db = SimpleNamespace(get_transcriber_languages=lambda username: [])
+
+    await server._handle_document_settings_selection(
+        user,
+        "delete_document",
+        {"folder_name": "private_doc", "category_slug": None},
+    )
+
+    assert server._user_states[user.username]["menu"] == "document_actions_menu"
+    assert_permission_denied(user)
+
+
+@pytest.mark.asyncio
+async def test_non_admin_cannot_add_transcriber_user(server):
+    user = make_user("player")
+    server._db = SimpleNamespace(
+        get_transcriber_languages=lambda username: [],
+        get_category_document_counts=lambda: {},
+    )
+
+    await server._handle_transcribers_by_user_selection(user, "add_user", {})
+
+    assert server._user_states[user.username]["menu"] == "documents_menu"
+    assert_permission_denied(user)
+
+
+@pytest.mark.asyncio
+async def test_handle_menu_rejects_selection_not_present_in_current_menu(server, monkeypatch):
+    user = make_user("player")
+    user.show_menu("main_menu", [MenuItem(text="Options", id="options")])
+    server._users = {user.username: user}
+    server._user_states[user.username] = {"menu": "main_menu"}
+    server._tables = SimpleNamespace(find_user_table=lambda username: None)
+
+    called = False
+
+    async def fake_dispatch(*args, **kwargs):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(server, "_dispatch_menu_selection", fake_dispatch)
+
+    await server._handle_menu(DummyClient(user.username), {"selection_id": "forged"})
+
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_handle_menu_allows_selection_present_in_current_menu(server, monkeypatch):
+    user = make_user("player")
+    user.show_menu("main_menu", [MenuItem(text="Options", id="options")])
+    server._users = {user.username: user}
+    server._user_states[user.username] = {"menu": "main_menu"}
+    server._tables = SimpleNamespace(find_user_table=lambda username: None)
+
+    seen = {}
+
+    async def fake_dispatch(dispatch_user, selection_id, state, current_menu):
+        seen["username"] = dispatch_user.username
+        seen["selection_id"] = selection_id
+        seen["current_menu"] = current_menu
+
+    monkeypatch.setattr(server, "_dispatch_menu_selection", fake_dispatch)
+
+    await server._handle_menu(DummyClient(user.username), {"selection_id": "options"})
+
+    assert seen == {
+        "username": user.username,
+        "selection_id": "options",
+        "current_menu": "main_menu",
+    }
+
+
+def test_admin_can_change_titles_without_transcriber_assignments(server, documents_dir):
+    admin = make_user("admin", trust=TrustLevel.ADMIN)
+    write_document(
+        documents_dir,
+        "title_doc",
+        (
+            '{"categories": [], "source_locale": "en", "titles": {"en": "Title Doc"}, '
+            '"locales": {"en": {"created": "2026-01-01T00:00:00Z", '
+            '"modified_contents": "2026-01-01T00:00:00Z", "public": true}}}'
+        ),
+        {"en": "hello"},
+    )
+    server._documents.load()
+    server._db = SimpleNamespace(get_transcriber_languages=lambda username: [])
+
+    server._show_document_title_languages(admin, "title_doc", {"category_slug": None})
+
+    assert server._user_states[admin.username]["menu"] == "document_title_lang_menu"
+    items = admin._current_menus["document_title_lang_menu"]["items"]
+    assert any(item["id"] == "lang_en" for item in items if isinstance(item, dict))
+
+
+def test_admin_can_add_translation_without_transcriber_assignments(server, documents_dir):
+    admin = make_user("admin", trust=TrustLevel.ADMIN)
+    write_document(
+        documents_dir,
+        "translation_doc",
+        (
+            '{"categories": [], "source_locale": "en", "titles": {"en": "Translation Doc"}, '
+            '"locales": {"en": {"created": "2026-01-01T00:00:00Z", '
+            '"modified_contents": "2026-01-01T00:00:00Z", "public": true}}}'
+        ),
+        {"en": "hello"},
+    )
+    server._documents.load()
+    server._db = SimpleNamespace(get_transcriber_languages=lambda username: [])
+
+    server._show_add_translation_languages(admin, "translation_doc", {"category_slug": None})
+
+    assert server._user_states[admin.username]["menu"] == "add_translation_lang_menu"
+    items = admin._current_menus["add_translation_lang_menu"]["items"]
+    assert any(item["id"] == "lang_fr" for item in items if isinstance(item, dict))
+
+
+def test_admin_can_open_delete_confirm_without_transcriber_assignments(server, documents_dir):
+    admin = make_user("admin", trust=TrustLevel.ADMIN)
+    write_document(
+        documents_dir,
+        "delete_doc",
+        (
+            '{"categories": [], "source_locale": "en", "titles": {"en": "Delete Doc"}, '
+            '"locales": {"en": {"created": "2026-01-01T00:00:00Z", '
+            '"modified_contents": "2026-01-01T00:00:00Z", "public": true}}}'
+        ),
+        {"en": "hello"},
+    )
+    server._documents.load()
+    server._db = SimpleNamespace(get_transcriber_languages=lambda username: [])
+
+    server._show_delete_document_confirm(admin, "delete_doc", {"category_slug": None})
+
+    assert server._user_states[admin.username]["menu"] == "delete_document_confirm"
+
+
+def test_document_view_uses_visible_title_for_fallback_locale(server, documents_dir):
+    user = make_user("reader", locale="en")
+    write_document(
+        documents_dir,
+        "visible_doc",
+        (
+            '{"categories": [], "source_locale": "fr", '
+            '"titles": {"en": "Private English", "fr": "Public French"}, '
+            '"locales": {'
+            '"en": {"created": "2026-01-01T00:00:00Z", "modified_contents": "2026-01-01T00:00:00Z", "public": false}, '
+            '"fr": {"created": "2026-01-01T00:00:00Z", "modified_contents": "2026-01-01T00:00:00Z", "public": true}'
+            '}}'
+        ),
+        {"en": "secret", "fr": "bonjour"},
+    )
+    server._documents.load()
+    server._db = SimpleNamespace(get_transcriber_languages=lambda username: [])
+
+    server._show_document_view(user, "visible_doc", {"category_slug": None})
+
+    packet = user.get_queued_messages()[-1]
+    assert packet["type"] == "request_input"
+    assert packet["prompt"] == "Public French"
+    assert packet["default_value"] == "bonjour"
+
+
+def test_document_view_does_not_fallback_to_private_english_title(server, documents_dir):
+    user = make_user("reader", locale="fr")
+    write_document(
+        documents_dir,
+        "title_safe_doc",
+        (
+            '{"categories": [], "source_locale": "fr", '
+            '"titles": {"en": "Private English"}, '
+            '"locales": {'
+            '"en": {"created": "2026-01-01T00:00:00Z", "modified_contents": "2026-01-01T00:00:00Z", "public": false}, '
+            '"fr": {"created": "2026-01-01T00:00:00Z", "modified_contents": "2026-01-01T00:00:00Z", "public": true}'
+            '}}'
+        ),
+        {"fr": "bonjour"},
+    )
+    server._documents.load()
+    server._db = SimpleNamespace(get_transcriber_languages=lambda username: [])
+
+    server._show_document_view(user, "title_safe_doc", {"category_slug": None})
+
+    packet = user.get_queued_messages()[-1]
+    assert packet["type"] == "request_input"
+    assert packet["prompt"] == "title_safe_doc"
+    assert packet["default_value"] == "bonjour"
+
+
+def test_document_view_skips_missing_visible_fallback_files(server, documents_dir):
+    user = make_user("reader", locale="en")
+    write_document(
+        documents_dir,
+        "fallback_doc",
+        (
+            '{"categories": [], "source_locale": "fr", '
+            '"titles": {"en": "Missing English", "fr": "French Title", "de": "German Title"}, '
+            '"locales": {'
+            '"en": {"created": "2026-01-01T00:00:00Z", "modified_contents": "2026-01-01T00:00:00Z", "public": true}, '
+            '"fr": {"created": "2026-01-01T00:00:00Z", "modified_contents": "2026-01-01T00:00:00Z", "public": true}, '
+            '"de": {"created": "2026-01-01T00:00:00Z", "modified_contents": "2026-01-01T00:00:00Z", "public": true}'
+            '}}'
+        ),
+        {"fr": "bonjour", "de": "guten tag"},
+    )
+    server._documents.load()
+    server._db = SimpleNamespace(get_transcriber_languages=lambda username: [])
+
+    server._show_document_view(user, "fallback_doc", {"category_slug": None})
+
+    packet = user.get_queued_messages()[-1]
+    assert packet["type"] == "request_input"
+    assert packet["prompt"] == "French Title"
+    assert packet["default_value"] == "bonjour"
+
+
+def test_documents_menu_counts_hide_fully_private_documents(server, documents_dir):
+    user = make_user("reader", locale="en")
+    write_document(
+        documents_dir,
+        "hidden_doc",
+        (
+            '{"categories": ["rules"], "source_locale": "en", '
+            '"titles": {"en": "Hidden Doc"}, '
+            '"locales": {"en": {"created": "2026-01-01T00:00:00Z", '
+            '"modified_contents": "2026-01-01T00:00:00Z", "public": false}}}'
+        ),
+        {"en": "secret"},
+    )
+    (documents_dir / "_metadata.json").write_text(
+        '{"categories": {"rules": {"sort": "alphabetical", "name": {"en": "Rules"}}}}',
+        encoding="utf-8",
+    )
+    server._documents.load()
+    server._db = SimpleNamespace(get_transcriber_languages=lambda username: [])
+
+    server._show_documents_menu(user)
+
+    items = server._users.get(user.username, user)._current_menus["documents_menu"]["items"]
+    assert any(item["id"] == "all" and item["text"] == "All documents (0)" for item in items)
+    assert not any(item["id"] == "cat_rules" for item in items)


### PR DESCRIPTION
## Summary
- harden documents and transcriber flows with server-side authorization checks
- reject forged menu selections that are not present in the active rendered menu
- enforce document visibility in listings, counts, and read fallbacks without leaking hidden titles

## Testing
- cd server && uv run pytest tests/test_document_manager.py tests/test_server_documents_security.py
- cd server && uv run pytest tests/test_server_menu_flow.py tests/test_server_admin_flows.py tests/test_server_authorization.py tests/test_server_authorize_flow.py tests/test_server_documents_security.py