### PR TITLE
Enable viewing other players' Yahtzee scoresheets

### DIFF
--- a/server/games/yahtzee/game.py
+++ b/server/games/yahtzee/game.py
@@ -323,7 +323,7 @@ class YahtzeeGame(ActionGuardMixin, Game, DiceGameMixin):
 
         self.define_keybind("d", "View dice", ["view_dice"], state=KeybindState.ACTIVE, include_spectators=True)
         self.define_keybind("c", "View scoresheet", ["view_scoresheet"], state=KeybindState.ACTIVE, include_spectators=True)
-        self.define_keybind("C", "View all scoresheets", ["view_all_scoresheets"], state=KeybindState.ACTIVE, include_spectators=True)
+        self.define_keybind("shift+c", "View all scoresheets", ["view_all_scoresheets"], state=KeybindState.ACTIVE, include_spectators=True)
 
     # ==========================================================================
     # Declarative Action Callbacks

--- a/server/games/yahtzee/game.py
+++ b/server/games/yahtzee/game.py
@@ -564,6 +564,7 @@ class YahtzeeGame(ActionGuardMixin, Game, DiceGameMixin):
 
         active_players = [p for p in self.players if not p.is_spectator]
         if not active_players:
+            user.speak_l("action-player-not-found")
             return
             
         items = [MenuItem(text=p.name, id=p.id) for p in active_players]

--- a/server/games/yahtzee/game.py
+++ b/server/games/yahtzee/game.py
@@ -648,6 +648,10 @@ class YahtzeeGame(ActionGuardMixin, Game, DiceGameMixin):
             target = self.get_player_by_id(selection_id)
             if target:
                 self._show_player_scoresheet(player, target)
+            else:
+                user = self.get_user(player)
+                if user:
+                    user.speak_l("action-player-not-found")
             return
 
         super()._handle_transient_display_selection(player, selection_id)

--- a/server/games/yahtzee/game.py
+++ b/server/games/yahtzee/game.py
@@ -569,6 +569,8 @@ class YahtzeeGame(ActionGuardMixin, Game, DiceGameMixin):
             return
 
         items = [MenuItem(text=p.name, id=p.id) for p in active_players]
+        back_label = Localization.get(user.locale, "back")
+        items.append(MenuItem(text=back_label, id="transient_display_back"))
         self._show_transient_display(
             player,
             kind="scoresheet_player_select",
@@ -646,6 +648,9 @@ class YahtzeeGame(ActionGuardMixin, Game, DiceGameMixin):
         """Handle a selection from the shared transient display menu."""
         state = self._get_transient_display_state(player)
         if state and state.kind == "scoresheet_player_select":
+            if selection_id == "transient_display_back":
+                self._close_transient_display(player)
+                return
             self._close_transient_display(player)
             target = self.get_player_by_id(selection_id)
             if target:

--- a/server/games/yahtzee/game.py
+++ b/server/games/yahtzee/game.py
@@ -299,6 +299,15 @@ class YahtzeeGame(ActionGuardMixin, Game, DiceGameMixin):
                 is_hidden="_is_view_scoresheet_hidden",
             )
         )
+        action_set.add(
+            Action(
+                id="view_all_scoresheets",
+                label=Localization.get(locale, "yahtzee-check-scoresheet"),
+                handler="_action_view_all_scoresheets",
+                is_enabled="_is_view_scoresheet_enabled",
+                is_hidden="_is_view_scoresheet_hidden",
+            )
+        )
 
         return action_set
 
@@ -315,6 +324,7 @@ class YahtzeeGame(ActionGuardMixin, Game, DiceGameMixin):
         # View actions
         self.define_keybind("d", "View dice", ["view_dice"], state=KeybindState.ACTIVE)
         self.define_keybind("c", "View scoresheet", ["view_scoresheet"], state=KeybindState.ACTIVE)
+        self.define_keybind("C", "View all scoresheets", ["view_all_scoresheets"], state=KeybindState.ACTIVE)
 
     # ==========================================================================
     # Declarative Action Callbacks
@@ -543,7 +553,11 @@ class YahtzeeGame(ActionGuardMixin, Game, DiceGameMixin):
             user.speak_l("yahtzee-your-dice", dice=dice_str)
 
     def _action_view_scoresheet(self, player: Player, action_id: str) -> None:
-        """View scoresheet menu."""
+        """View your own scoresheet."""
+        self._show_player_scoresheet(player, player)
+
+    def _action_view_all_scoresheets(self, player: Player, action_id: str) -> None:
+        """View scoresheet menu for all players."""
         user = self.get_user(player)
         if not user:
             return

--- a/server/games/yahtzee/game.py
+++ b/server/games/yahtzee/game.py
@@ -321,10 +321,9 @@ class YahtzeeGame(ActionGuardMixin, Game, DiceGameMixin):
         # Toggle dice (1-5 keys) - from DiceGameMixin
         self.setup_dice_keybinds()
 
-        # View actions
-        self.define_keybind("d", "View dice", ["view_dice"], state=KeybindState.ACTIVE)
-        self.define_keybind("c", "View scoresheet", ["view_scoresheet"], state=KeybindState.ACTIVE)
-        self.define_keybind("C", "View all scoresheets", ["view_all_scoresheets"], state=KeybindState.ACTIVE)
+        self.define_keybind("d", "View dice", ["view_dice"], state=KeybindState.ACTIVE, include_spectators=True)
+        self.define_keybind("c", "View scoresheet", ["view_scoresheet"], state=KeybindState.ACTIVE, include_spectators=True)
+        self.define_keybind("C", "View all scoresheets", ["view_all_scoresheets"], state=KeybindState.ACTIVE, include_spectators=True)
 
     # ==========================================================================
     # Declarative Action Callbacks
@@ -554,6 +553,8 @@ class YahtzeeGame(ActionGuardMixin, Game, DiceGameMixin):
 
     def _action_view_scoresheet(self, player: Player, action_id: str) -> None:
         """View your own scoresheet."""
+        if player.is_spectator:
+            return self._action_view_all_scoresheets(player, action_id)
         self._show_player_scoresheet(player, player)
 
     def _action_view_all_scoresheets(self, player: Player, action_id: str) -> None:

--- a/server/games/yahtzee/game.py
+++ b/server/games/yahtzee/game.py
@@ -302,7 +302,7 @@ class YahtzeeGame(ActionGuardMixin, Game, DiceGameMixin):
         action_set.add(
             Action(
                 id="view_all_scoresheets",
-                label=Localization.get(locale, "yahtzee-check-scoresheet"),
+                label=Localization.get(locale, "yahtzee-check-all-scoresheets"),
                 handler="_action_view_all_scoresheets",
                 is_enabled="_is_view_scoresheet_enabled",
                 is_hidden="_is_view_scoresheet_hidden",

--- a/server/games/yahtzee/game.py
+++ b/server/games/yahtzee/game.py
@@ -642,17 +642,15 @@ class YahtzeeGame(ActionGuardMixin, Game, DiceGameMixin):
 
     def _handle_transient_display_selection(self, player: Player, selection_id: str) -> None:
         """Handle a selection from the shared transient display menu."""
-        super()._handle_transient_display_selection(player, selection_id)
-        
         state = self._get_transient_display_state(player)
-        if not state:
-            return
-
-        if state.kind == "scoresheet_player_select":
+        if state and state.kind == "scoresheet_player_select":
             self._close_transient_display(player)
             target = self.get_player_by_id(selection_id)
             if target:
                 self._show_player_scoresheet(player, target)
+            return
+
+        super()._handle_transient_display_selection(player, selection_id)
 
     def on_start(self) -> None:
         """Called when the game starts."""

--- a/server/games/yahtzee/game.py
+++ b/server/games/yahtzee/game.py
@@ -27,6 +27,7 @@ from ...game_utils.game_result import GameResult, PlayerResult
 from ...game_utils.options import IntOption, option_field
 from ...messages.localization import Localization
 from server.core.ui.keybinds import KeybindState
+from server.core.users.base import MenuItem
 
 
 # Scoring categories
@@ -542,32 +543,45 @@ class YahtzeeGame(ActionGuardMixin, Game, DiceGameMixin):
             user.speak_l("yahtzee-your-dice", dice=dice_str)
 
     def _action_view_scoresheet(self, player: Player, action_id: str) -> None:
-        """View scoresheet."""
+        """View scoresheet menu."""
         user = self.get_user(player)
         if not user:
             return
 
-        # Show current player's scoresheet
-        current = self.current_player
-        if not current:
+        active_players = [p for p in self.players if not p.is_spectator]
+        if not active_players:
+            return
+            
+        items = [MenuItem(text=p.name, id=p.id) for p in active_players]
+        self._show_transient_display(
+            player,
+            kind="scoresheet_player_select",
+            items=items,
+            multiletter=True,
+        )
+
+    def _show_player_scoresheet(self, viewer: Player, target: Player) -> None:
+        """Show a specific player's scoresheet to the viewer."""
+        user = self.get_user(viewer)
+        if not user:
             return
 
-        ytz_current: YahtzeePlayer = current  # type: ignore
+        ytz_target: YahtzeePlayer = target  # type: ignore
         locale = user.locale
 
-        lines = [Localization.get(locale, "yahtzee-scoresheet-header", player=current.name)]
+        lines = [Localization.get(locale, "yahtzee-scoresheet-header", player=target.name)]
         lines.append(Localization.get(locale, "yahtzee-scoresheet-upper"))
 
         for cat in UPPER_CATEGORIES:
             cat_name = Localization.get(locale, CATEGORY_NAMES[cat])
-            score = ytz_current.scores.get(cat)
+            score = ytz_target.scores.get(cat)
             if score is not None:
                 lines.append(f"  {cat_name}: {score}")
             else:
                 lines.append(f"  {cat_name}: -")
 
-        upper_total = ytz_current.get_upper_total()
-        if ytz_current.upper_bonus_awarded:
+        upper_total = ytz_target.get_upper_total()
+        if ytz_target.upper_bonus_awarded:
             lines.append(
                 Localization.get(locale, "yahtzee-scoresheet-upper-total-bonus", total=upper_total)
             )
@@ -586,18 +600,18 @@ class YahtzeeGame(ActionGuardMixin, Game, DiceGameMixin):
 
         for cat in LOWER_CATEGORIES:
             cat_name = Localization.get(locale, CATEGORY_NAMES[cat])
-            score = ytz_current.scores.get(cat)
+            score = ytz_target.scores.get(cat)
             if score is not None:
                 lines.append(f"  {cat_name}: {score}")
             else:
                 lines.append(f"  {cat_name}: -")
 
-        yahtzee_bonus = ytz_current.yahtzee_bonus_count * 100
+        yahtzee_bonus = ytz_target.yahtzee_bonus_count * 100
         lines.append(
             Localization.get(
                 locale,
                 "yahtzee-scoresheet-yahtzee-bonus",
-                count=ytz_current.yahtzee_bonus_count,
+                count=ytz_target.yahtzee_bonus_count,
                 total=yahtzee_bonus,
             )
         )
@@ -606,11 +620,25 @@ class YahtzeeGame(ActionGuardMixin, Game, DiceGameMixin):
             Localization.get(
                 locale,
                 "yahtzee-scoresheet-grand-total",
-                total=ytz_current.get_total_score(),
+                total=ytz_target.get_total_score(),
             )
         )
 
-        self.status_box(player, lines)
+        self.status_box(viewer, lines)
+
+    def _handle_transient_display_selection(self, player: Player, selection_id: str) -> None:
+        """Handle a selection from the shared transient display menu."""
+        super()._handle_transient_display_selection(player, selection_id)
+        
+        state = self._get_transient_display_state(player)
+        if not state:
+            return
+
+        if state.kind == "scoresheet_player_select":
+            self._close_transient_display(player)
+            target = self.get_player_by_id(selection_id)
+            if target:
+                self._show_player_scoresheet(player, target)
 
     def on_start(self) -> None:
         """Called when the game starts."""

--- a/server/games/yahtzee/game.py
+++ b/server/games/yahtzee/game.py
@@ -566,7 +566,7 @@ class YahtzeeGame(ActionGuardMixin, Game, DiceGameMixin):
         if not active_players:
             user.speak_l("action-player-not-found")
             return
-            
+
         items = [MenuItem(text=p.name, id=p.id) for p in active_players]
         self._show_transient_display(
             player,

--- a/server/games/yahtzee/game.py
+++ b/server/games/yahtzee/game.py
@@ -302,7 +302,7 @@ class YahtzeeGame(ActionGuardMixin, Game, DiceGameMixin):
         action_set.add(
             Action(
                 id="view_all_scoresheets",
-                label=Localization.get(locale, "yahtzee-check-all-scoresheets"),
+                label=Localization.get(locale, "yahtzee-check-scoresheet"),
                 handler="_action_view_all_scoresheets",
                 is_enabled="_is_view_scoresheet_enabled",
                 is_hidden="_is_view_scoresheet_hidden",

--- a/server/locales/en/main.ftl
+++ b/server/locales/en/main.ftl
@@ -179,6 +179,7 @@ table-saved-destroying = Table saved! Returning to main menu.
 game-type-not-found = Game type no longer exists.
 
 # Action disabled reasons
+action-player-not-found = Player not found.
 action-not-your-turn = It's not your turn.
 action-not-playing = The game hasn't started.
 action-spectator = Spectators cannot do this.

--- a/server/locales/en/yahtzee.ftl
+++ b/server/locales/en/yahtzee.ftl
@@ -48,6 +48,7 @@ yahtzee-continuing = Continuing turn.
 
 # Status checks
 yahtzee-check-scoresheet = Check scorecard
+yahtzee-check-all-scoresheets = Check all scorecards
 yahtzee-view-dice = Check your dice
 yahtzee-your-dice = Your dice: { $dice }.
 yahtzee-your-dice-kept = Your dice: { $dice }. Keeping: { $kept }

--- a/server/locales/en/yahtzee.ftl
+++ b/server/locales/en/yahtzee.ftl
@@ -48,7 +48,6 @@ yahtzee-continuing = Continuing turn.
 
 # Status checks
 yahtzee-check-scoresheet = Check scorecard
-yahtzee-check-all-scoresheets = Check all scorecards
 yahtzee-view-dice = Check your dice
 yahtzee-your-dice = Your dice: { $dice }.
 yahtzee-your-dice-kept = Your dice: { $dice }. Keeping: { $kept }

--- a/server/tests/test_yahtzee_scoresheet_select.py
+++ b/server/tests/test_yahtzee_scoresheet_select.py
@@ -1,0 +1,240 @@
+"""Tests for the scoresheet picker flow added in PR #243.
+
+PR #243 added the ability to view any active player's Yahtzee scoresheet.
+
+Keybind layout (active players):
+- ``c``      -> immediately show the viewer's own scoresheet (status_box).
+- ``shift+c`` -> open a transient picker (scoresheet_player_select) listing all
+  active players + a Back item; selecting a player shows their scoresheet.
+
+For spectators (no own scoresheet), ``c`` falls back to the picker so the
+experience is seamless.
+"""
+
+from __future__ import annotations
+
+from server.core.users.base import MenuItem
+from server.core.users.test_user import MockUser
+from server.games.yahtzee.game import YahtzeeGame
+
+
+def _last_show_menu_for(user: MockUser, menu_id: str) -> dict | None:
+    for m in reversed(user.messages):
+        if m.type == "show_menu" and m.data.get("menu_id") == menu_id:
+            return m.data
+    return None
+
+
+def _item_id(item) -> str:
+    return item.id if isinstance(item, MenuItem) else item["id"]
+
+
+def _item_text(item) -> str:
+    return item.text if isinstance(item, MenuItem) else item["text"]
+
+
+def _spoken_texts(user: MockUser) -> list[str]:
+    return [m.data["text"] for m in user.messages if m.type == "speak"]
+
+
+def _make_game(player_specs: list[tuple[str, str]], spectators: list[str] | None = None):
+    """Build a started YahtzeeGame.
+
+    player_specs: list of (name, locale) for active players.
+    spectators: list of names for spectators.
+    Returns (game, players_by_name, users_by_name).
+    """
+    game = YahtzeeGame()
+    users: dict[str, MockUser] = {}
+    players: dict = {}
+    for name, locale in player_specs:
+        user = MockUser(name, locale=locale)
+        users[name] = user
+        players[name] = game.add_player(name, user)
+    for name in spectators or []:
+        user = MockUser(name)
+        users[name] = user
+        players[name] = game.add_spectator(name, user)
+    game.on_start()
+    # Clear startup chatter so menu-finders don't trip on stale messages.
+    for u in users.values():
+        u.clear_messages()
+    return game, players, users
+
+
+# ---------------------------------------------------------------------------
+# `c` (own sheet) path
+# ---------------------------------------------------------------------------
+
+
+def test_view_scoresheet_active_player_shows_own_sheet_immediately():
+    """Active player pressing `c` should see their own scoresheet directly,
+    not the picker."""
+    game, players, users = _make_game([("Alice", "en"), ("Bob", "en")])
+    alice = players["Alice"]
+
+    game._action_view_scoresheet(alice, "view_scoresheet")
+
+    state = game._get_transient_display_state(alice)
+    assert state is not None
+    assert state.kind == "status_box", f"expected status_box, got {state.kind!r}"
+
+    menu = _last_show_menu_for(users["Alice"], "transient_display")
+    assert menu is not None
+    text_blob = " ".join(_item_text(it) for it in menu["items"])
+    assert "Alice" in text_blob, "viewer's own name should be in the header"
+    assert "Bob" not in text_blob
+
+
+# ---------------------------------------------------------------------------
+# `shift+c` (picker) path
+# ---------------------------------------------------------------------------
+
+
+def test_view_all_scoresheets_opens_player_picker():
+    game, players, users = _make_game([("Alice", "en"), ("Bob", "en")])
+    alice = players["Alice"]
+
+    game._action_view_all_scoresheets(alice, "view_all_scoresheets")
+
+    state = game._get_transient_display_state(alice)
+    assert state is not None
+    assert state.kind == "scoresheet_player_select"
+
+    menu = _last_show_menu_for(users["Alice"], "transient_display")
+    assert menu is not None
+    item_ids = [_item_id(it) for it in menu["items"]]
+    assert players["Alice"].id in item_ids
+    assert players["Bob"].id in item_ids
+    assert "transient_display_back" in item_ids, "Back item should be last entry"
+
+
+def test_view_all_scoresheets_excludes_spectators_from_picker():
+    game, players, users = _make_game(
+        [("Alice", "en"), ("Bob", "en")],
+        spectators=["Spec"],
+    )
+    alice = players["Alice"]
+
+    game._action_view_all_scoresheets(alice, "view_all_scoresheets")
+
+    menu = _last_show_menu_for(users["Alice"], "transient_display")
+    assert menu is not None
+    item_ids = [_item_id(it) for it in menu["items"]]
+    assert players["Spec"].id not in item_ids, "spectators should not appear as targets"
+    assert players["Alice"].id in item_ids
+    assert players["Bob"].id in item_ids
+
+
+def test_selecting_player_in_picker_renders_their_scoresheet():
+    game, players, users = _make_game([("Alice", "en"), ("Bob", "en")])
+    alice = players["Alice"]
+    bob = players["Bob"]
+    bob.scores["ones"] = 3
+    bob.scores["yahtzee"] = 50
+
+    game._action_view_all_scoresheets(alice, "view_all_scoresheets")
+    game._handle_transient_display_selection(alice, bob.id)
+
+    state = game._get_transient_display_state(alice)
+    assert state is not None
+    assert state.kind == "status_box"
+
+    box_menu = _last_show_menu_for(users["Alice"], "transient_display")
+    assert box_menu is not None
+    text_blob = " ".join(_item_text(it) for it in box_menu["items"])
+    assert "Bob" in text_blob, "scoresheet should be for Bob (the selected target)"
+
+
+def test_selecting_back_in_picker_closes_it_without_opening_sheet():
+    game, players, users = _make_game([("Alice", "en"), ("Bob", "en")])
+    alice = players["Alice"]
+
+    game._action_view_all_scoresheets(alice, "view_all_scoresheets")
+    assert game._get_transient_display_state(alice).kind == "scoresheet_player_select"
+
+    game._handle_transient_display_selection(alice, "transient_display_back")
+
+    assert game._get_transient_display_state(alice) is None
+
+
+# ---------------------------------------------------------------------------
+# Spectator fallback: `c` opens picker because spectators have no own sheet.
+# ---------------------------------------------------------------------------
+
+
+def test_spectator_pressing_view_scoresheet_falls_back_to_picker():
+    game, players, users = _make_game(
+        [("Alice", "en")],
+        spectators=["Spec"],
+    )
+    spec = players["Spec"]
+
+    game._action_view_scoresheet(spec, "view_scoresheet")
+
+    state = game._get_transient_display_state(spec)
+    assert state is not None
+    assert state.kind == "scoresheet_player_select", (
+        "spectator with no own sheet should be routed to the picker"
+    )
+
+    menu = _last_show_menu_for(users["Spec"], "transient_display")
+    assert menu is not None
+    item_ids = [_item_id(it) for it in menu["items"]]
+    assert players["Alice"].id in item_ids
+    assert spec.id not in item_ids, "spectator should not appear as a target"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases: silence-is-a-bug feedback.
+# ---------------------------------------------------------------------------
+
+
+def test_picker_with_no_active_players_speaks_not_found():
+    """If the picker is somehow triggered with no active players, the action
+    must produce speech (per CLAUDE.md "silence is a bug")."""
+    game = YahtzeeGame()
+    user = MockUser("Spec")
+    spec = game.add_spectator("Spec", user)
+    user.clear_messages()
+
+    game._action_view_all_scoresheets(spec, "view_all_scoresheets")
+
+    assert game._get_transient_display_state(spec) is None
+    assert "Player not found." in _spoken_texts(user)
+
+
+def test_picker_with_stale_selection_id_speaks_not_found():
+    """If a player is selected from the picker but has since disconnected /
+    been removed, the action must produce speech rather than silently dropping."""
+    game, players, users = _make_game([("Alice", "en"), ("Bob", "en")])
+    alice = players["Alice"]
+
+    game._action_view_all_scoresheets(alice, "view_all_scoresheets")
+    users["Alice"].clear_messages()
+
+    game._handle_transient_display_selection(alice, "nonexistent-player-id")
+
+    assert game._get_transient_display_state(alice) is None
+    assert "Player not found." in _spoken_texts(users["Alice"])
+
+
+# ---------------------------------------------------------------------------
+# Re-pressing shift+c while a sheet is open should reopen the picker.
+# ---------------------------------------------------------------------------
+
+
+def test_pressing_view_all_scoresheets_again_replaces_open_sheet_with_picker():
+    game, players, users = _make_game([("Alice", "en"), ("Bob", "en")])
+    alice = players["Alice"]
+    bob = players["Bob"]
+
+    game._action_view_all_scoresheets(alice, "view_all_scoresheets")
+    game._handle_transient_display_selection(alice, bob.id)
+    assert game._get_transient_display_state(alice).kind == "status_box"
+
+    game._action_view_all_scoresheets(alice, "view_all_scoresheets")
+
+    state = game._get_transient_display_state(alice)
+    assert state is not None
+    assert state.kind == "scoresheet_player_select"


### PR DESCRIPTION
## Summary
Lets a Yahtzee player view any other active player's scoresheet without leaving the game. Adds a separate keybind for the picker so the common case (viewing your own sheet) stays a single keystroke.

## Keybind layout
- **`c`** — show your own scoresheet immediately (active players). Spectators have no own sheet, so `c` falls back to the picker.
- **`shift+c`** — open a transient player picker listing every active player + Back; selecting a player renders their scoresheet.
- **`d`** (view dice), **`c`**, and **`shift+c`** are all now `include_spectators=True`, so spectators can inspect dice and scoresheets too.

## Code changes
- New `_action_view_all_scoresheets` that opens the `scoresheet_player_select` transient display with the active players + Back.
- New `_show_player_scoresheet` helper that renders a target player's sheet to the viewer (viewer's locale, target's data).
- `_action_view_scoresheet` (own sheet) now routes spectators to the picker.
- `_handle_transient_display_selection` handles `scoresheet_player_select` locally before delegating to the base class (kind-first dispatch, not super-then-state).
- Speech feedback ("Player not found.") when the picker is opened with no active players or a stale selection ID — adheres to CLAUDE.md "silence is a bug".
- Removed dead Fluent entry `yahtzee-check-all-scoresheets`; the `view_all_scoresheets` action is hidden, so its label is never rendered.

## Tests
`server/tests/test_yahtzee_scoresheet_select.py` (9 tests):
- `c` on an active player shows their own scoresheet directly (not the picker).
- `shift+c` opens the picker with all active players + Back item.
- Picker excludes spectators from the target list.
- Selecting a player renders that player's sheet via `status_box`.
- Selecting Back closes the picker without opening a sheet.
- Spectator pressing `c` falls back to the picker.
- Empty active-players list speaks "Player not found." rather than failing silently.
- Stale selection ID after picker open speaks "Player not found.".
- Re-pressing `shift+c` while a sheet is open reopens the picker.

## Testing notes
- Existing yahtzee suite (28) + new tests (9) all pass: `uv run pytest tests/test_yahtzee.py tests/test_yahtzee_scoresheet_select.py`
- CLI sim runs to completion and all 30 keybinds validate: `uv run cli.py simulate yahtzee --bots 3 --validate-keybinds`