### PR TITLE
Gate tree-selection bookkeeping test to macOS

### DIFF
--- a/clients/desktop/tests/test_tree_selection.py
+++ b/clients/desktop/tests/test_tree_selection.py
@@ -69,6 +69,7 @@ def test_managed_tree_ctrl_select_after_delete_prefers_configured_neighbor(wx_ap
         frame.Destroy()
 
 
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS TreeListCtrl shim only")
 def test_managed_tree_ctrl_delete_all_items_resets_bookkeeping(wx_app):
     frame = wx.Frame(None)
     panel = wx.Panel(frame)


### PR DESCRIPTION
## Summary
- Skip `test_managed_tree_ctrl_delete_all_items_resets_bookkeeping` on non-darwin. It exercises the macOS `TreeListCtrl` shim's bookkeeping (`_item_data` reset, persistent compat-root); on Windows/Linux `ManagedTreeCtrl` is a `wx.TreeCtrl` whose root becomes invalid after `DeleteAllItems` and whose stale `TreeItemId`s are undefined, so the test fails with `wxAssertionError: "item.IsOk()" failed`.
- Mirrors the existing `sys.platform != "darwin"` gate on `test_managed_tree_ctrl_rejects_unsupported_tree_event_binders`.
- Follow-up to #244 ([context](https://github.com/XGDevGroup/PlayPalace11/pull/244#issuecomment-4353716264)).

## Test plan
- [x] `uv run python -m pytest tests/test_tree_selection.py -v` on Windows: 2 passed, 2 skipped, 0 failed.
- [ ] Same command on macOS should run all 4 tests (the gated one will execute the shim path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)