### PR TITLE
Type Game.status as GameStatus instead of str

### DIFF
--- a/server/games/base.py
+++ b/server/games/base.py
@@ -32,7 +32,7 @@ from ..game_utils.event_handling_mixin import EventHandlingMixin
 from ..game_utils.action_set_creation_mixin import ActionSetCreationMixin
 from ..game_utils.action_execution_mixin import ActionExecutionMixin
 from ..game_utils.action_set_system_mixin import ActionSetSystemMixin
-from ..game_utils.game_status import GameStatus  # noqa: F401 - re-exported
+from ..game_utils.game_status import GameStatus
 from server.core.ui.keybinds import Keybind
 
 
@@ -106,7 +106,7 @@ if TYPE_CHECKING:
         """
 
         players: list[Player]
-        status: str
+        status: GameStatus
         game_active: bool
         host: str
         round: int
@@ -171,7 +171,7 @@ class Game(
     players: list[Player] = field(default_factory=list)
     round: int = 0
     game_active: bool = False
-    status: str = GameStatus.WAITING
+    status: GameStatus = GameStatus.WAITING
     host: str = ""  # Username of the host
     current_music: str = ""  # Currently playing music track
     current_ambience: str = ""  # Currently playing ambience loop


### PR DESCRIPTION
## Summary

Follow-up to #226 (review comment item 2). The field was left as
`status: str = GameStatus.WAITING` — declared `str`, assigned enum.
Mashumaro looks at the declared type to (de)serialize, so a round-trip
would silently downcast the field to a plain `str`.

This PR changes the field and the `GameProtocol` declaration to
`status: GameStatus`. Equality comparisons against raw strings (the
existing pattern across game files) keep working via `GameStatus(str, Enum)`'s
str inheritance.

## Test plan

- [x] Probed `PigGame.to_dict() → from_dict()` round-trip: before this
      change the deserialized field was `str('playing')`; after, it is
      `GameStatus.PLAYING`.
- [x] `pytest tests/test_event_handling_mixin.py tests/test_game_communication_mixin.py tests/test_pig.py tests/test_table_manager.py tests/test_keybinds.py tests/test_database.py tests/test_integration.py tests/test_server_tables_menus.py` — 94 passed.
- [x] `cli.py simulate pig --bots 2 --test-serialization` completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)