### PR TITLE
Fix iPhone history lag: cap web client history buffers and coalesce renders

### DIFF
--- a/clients/web/store.js
+++ b/clients/web/store.js
@@ -1,3 +1,16 @@
+// Cap each history buffer so a long session can't grow the arrays (and the
+// per-render join/DOM rebuild) without bound. Older lines drop off the front.
+// This is the main guard against the mobile "taps get slower over time" lag.
+const HISTORY_BUFFER_LIMIT = 500;
+
+function pushCappedHistory(lines, text) {
+  lines.push(text);
+  const overflow = lines.length - HISTORY_BUFFER_LIMIT;
+  if (overflow > 0) {
+    lines.splice(0, overflow);
+  }
+}
+
 export function createStore() {
   const state = {
     connection: {
@@ -58,9 +71,9 @@ export function createStore() {
       if (!state.historyBuffers[buffer]) {
         state.historyBuffers[buffer] = [];
       }
-      state.historyBuffers[buffer].push(text);
+      pushCappedHistory(state.historyBuffers[buffer], text);
       if (buffer !== "all") {
-        state.historyBuffers.all.push(text);
+        pushCappedHistory(state.historyBuffers.all, text);
       }
       notify();
     },

--- a/clients/web/ui/history.js
+++ b/clients/web/ui/history.js
@@ -12,7 +12,8 @@ export function createHistoryView({
   const isMobileLike = window.matchMedia("(pointer: coarse)").matches;
   let mobileCollapsed = isMobileLike;
   let renderedLogBuffer = "";
-  let renderedLogCount = 0;
+  let renderedLogValue = null;
+  let renderScheduled = false;
 
   function ensureBufferPosition(bufferName) {
     if (!Object.hasOwn(bufferPositions, bufferName)) {
@@ -72,38 +73,56 @@ export function createHistoryView({
     }
   }
 
-  function render() {
+  function flushRender() {
+    renderScheduled = false;
     for (const name of getBufferNames()) {
       ensureBufferPosition(name);
     }
     const bufferName = store.state.historyBuffer;
     const lines = store.state.historyBuffers[bufferName] || [];
-    historyEl.value = lines.join("\n");
+    const joined = lines.join("\n");
+
+    // Skip the DOM work entirely when nothing in the visible buffer changed.
+    // notify() fires on every state change (menu navigation, audio, etc.), so
+    // most flushes here are no-ops — this keeps arrow-key menu moves cheap.
+    if (bufferName === renderedLogBuffer && joined === renderedLogValue) {
+      return;
+    }
+    renderedLogBuffer = bufferName;
+    renderedLogValue = joined;
+
+    historyEl.value = joined;
     historyEl.scrollTop = historyEl.scrollHeight;
 
     if (historyLogEl) {
-      const needsRebuild = renderedLogBuffer !== bufferName || renderedLogCount > lines.length;
-      if (needsRebuild) {
-        historyLogEl.replaceChildren();
-        for (const line of lines) {
-          const row = document.createElement("p");
-          row.className = "history-line";
-          row.textContent = line;
-          historyLogEl.appendChild(row);
-        }
-        renderedLogBuffer = bufferName;
-        renderedLogCount = lines.length;
-      } else if (lines.length > renderedLogCount) {
-        for (let i = renderedLogCount; i < lines.length; i += 1) {
-          const row = document.createElement("p");
-          row.className = "history-line";
-          row.textContent = lines[i];
-          historyLogEl.appendChild(row);
-        }
-        renderedLogBuffer = bufferName;
-        renderedLogCount = lines.length;
+      // Rebuild from scratch (bounded by the store's per-buffer cap). A full
+      // rebuild is correct even when the cap trims lines off the front, which
+      // the previous incremental count-based append could not detect.
+      const fragment = document.createDocumentFragment();
+      for (const line of lines) {
+        const row = document.createElement("p");
+        row.className = "history-line";
+        row.textContent = line;
+        fragment.appendChild(row);
       }
+      historyLogEl.replaceChildren(fragment);
       historyLogEl.scrollTop = historyLogEl.scrollHeight;
+    }
+  }
+
+  // Coalesce bursts of notify() calls (a single tap can append many lines, each
+  // firing notify()) into one render per animation frame instead of one render
+  // per line. This is what turns the old O(lines added * buffer size) churn per
+  // tap into a single bounded render.
+  function render() {
+    if (renderScheduled) {
+      return;
+    }
+    renderScheduled = true;
+    if (typeof requestAnimationFrame === "function") {
+      requestAnimationFrame(flushRender);
+    } else {
+      flushRender();
     }
   }
 


### PR DESCRIPTION
## Problem

On iPhone, tapping a menu choice grows to **10–20s of lag** after a session has run for a while. Desktop is unaffected.

Root cause is the web client's history system:

- `store.addHistory()` pushes to history buffers with **no cap**, and every non-`all` line is also mirrored into the `all` buffer (the default visible one) — so buffers grow with the entire session.
- `history.js` `render()` runs on **every** `notify()` and rebuilds the whole `<textarea>` via `lines.join("\n")` plus a forced reflow (`scrollTop = scrollHeight`). A single tap emits a *burst* of `speak`/`chat` lines, each firing its own `notify()`, so cost per tap ≈ **(lines added) × (total history)** — quadratic and growing all session.
- Mobile is hit hardest: `renderMobileVisibility()` shows the growing `#history-log` `<p>` list that desktop hides, so phones pay for both the textarea rebuild and an unbounded visible DOM, on slower hardware.

## Fix

- **`store.js`** — cap each history buffer at **500 lines** (FIFO trim from the front). Bounds memory and makes every render `O(cap)` instead of `O(session)`. History navigation indexes from the end, so front-trimming never disturbs scrollback position.
- **`ui/history.js`** — coalesce renders into one `requestAnimationFrame` (a K-line burst → **1** render, not K), skip the DOM work entirely when the visible buffer is unchanged (keeps menu navigation cheap), and rebuild the capped log from scratch (the old count-based incremental append silently broke once the buffer trimmed from the front).

## Testing

- Focused unit check of the cap (600 pushes → length 500, oldest dropped, `all` mirror capped, direct-`all` path not double-pushed): **pass**.
- Existing web tests (`tests/markdown_viewer_security.test.mjs`): **2/2 pass**.

## Notes

- Intentionally **did not** bump `version.js` in this PR to avoid merge conflicts in the integration branch; asset freshness is already handled by the server's `Cache-Control: no-cache, must-revalidate` + ETag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)