### PR TITLE
Fix undefined forward-ref type annotations and remove dead duplicate tests

### DIFF
--- a/server/core/server.py
+++ b/server/core/server.py
@@ -36,9 +36,10 @@ from .documents.browsing import DocumentBrowsingMixin, _DOCUMENTS_DIR
 from .documents.transcriber_role import TranscriberRoleMixin
 from .virtual_bots import VirtualBotManager
 from ..network.websocket_server import WebSocketServer, ClientConnection
-from ..persistence.database import Database
+from ..persistence.database import Database, UserRecord
 from ..auth.auth import AuthManager, AuthResult
 from .tables.manager import TableManager
+from .tables.table import Table
 from .users.network_user import NetworkUser
 from .users.base import MenuItem, EscapeBehavior, TrustLevel
 from .users.preferences import UserPreferences, DiceKeepingStyle, PREF_CATEGORIES, PrefMeta
@@ -1133,7 +1134,7 @@ class Server(AdministrationMixin, DocumentBrowsingMixin, TranscriberRoleMixin):
         if not self._restore_login_table(user, username):
             self._show_main_menu(user)
 
-    def _load_user_preferences(self, user_record: "AuthUserRecord") -> UserPreferences:
+    def _load_user_preferences(self, user_record: "UserRecord") -> UserPreferences:
         """Load stored preferences, falling back to defaults."""
         if user_record.preferences_json:
             try:
@@ -1150,7 +1151,7 @@ class Server(AdministrationMixin, DocumentBrowsingMixin, TranscriberRoleMixin):
         self,
         client: ClientConnection,
         username: str,
-        user_record: "AuthUserRecord",
+        user_record: "UserRecord",
         preferences: UserPreferences,
     ) -> tuple[NetworkUser, bool]:
         """Attach a connection to an existing user or create a new one."""

--- a/server/core/virtual_bots.py
+++ b/server/core/virtual_bots.py
@@ -903,7 +903,7 @@ class VirtualBotManager:
         """Build snapshot data for guided table rules."""
         return [self._build_guided_state_snapshot(state) for state in self._iter_guided_states()]
 
-    def _build_guided_state_snapshot(self, state: "GuidedTableRuleState") -> dict[str, Any]:
+    def _build_guided_state_snapshot(self, state: "GuidedTableState") -> dict[str, Any]:
         """Build a snapshot for a single guided rule state."""
         config = state.config
         assigned = len(state.assigned_bots)
@@ -937,7 +937,7 @@ class VirtualBotManager:
             "unavailable_bots": unavailable,
         }
 
-    def _count_guided_availability(self, state: "GuidedTableRuleState") -> tuple[int, int]:
+    def _count_guided_availability(self, state: "GuidedTableState") -> tuple[int, int]:
         """Count guided bots waiting vs unavailable for a rule."""
         waiting = 0
         unavailable = 0
@@ -958,7 +958,7 @@ class VirtualBotManager:
         return waiting, unavailable
 
     def _describe_guided_table(
-        self, state: "GuidedTableRuleState"
+        self, state: "GuidedTableState"
     ) -> tuple[str, str | None, int, int]:
         """Describe the guided table link and player counts."""
         if not state.table_id:

--- a/server/games/ageofheroes/bot.py
+++ b/server/games/ageofheroes/bot.py
@@ -33,6 +33,7 @@ from .trading import create_offer, announce_offer, check_and_execute_trades
 
 if TYPE_CHECKING:
     from .game import AgeOfHeroesGame, AgeOfHeroesPlayer
+    from .state import TribeState
 
 
 def bot_think(game: AgeOfHeroesGame, player: AgeOfHeroesPlayer) -> str | None:

--- a/server/games/backgammon/game.py
+++ b/server/games/backgammon/game.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 import random
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .gnubg import GnubgProcess
 
 log = logging.getLogger(__name__)
 

--- a/server/games/chaosbear/game.py
+++ b/server/games/chaosbear/game.py
@@ -406,7 +406,7 @@ class ChaosBearGame(Game):
         # Otherwise roll the dice
         return "roll_dice"
 
-    def _start_next_turn(self, previous_player: "ChaosPlayer | None" = None) -> None:
+    def _start_next_turn(self, previous_player: "ChaosBearPlayer | None" = None) -> None:
         """Start the next player's turn with menu rebuild and bot jolt.
 
         Args:

--- a/server/games/sorry/game.py
+++ b/server/games/sorry/game.py
@@ -28,6 +28,7 @@ from .rules import (
 )
 from .state import (
     SorryGameState,
+    SorryPawnState,
     SorryPlayerState,
     build_initial_game_state,
     discard_current_card,

--- a/server/tests/test_server_admin_virtual_bots.py
+++ b/server/tests/test_server_admin_virtual_bots.py
@@ -82,9 +82,6 @@ class DummyBotsManager:
         self.cleared = True
         return 2, 0
 
-    def save_state(self):
-        self.saved = True
-
     def get_status(self):
         return {"online": 0, "total": 0, "offline": 0, "in_game": 0}
 

--- a/server/tests/test_virtual_bots.py
+++ b/server/tests/test_virtual_bots.py
@@ -1311,42 +1311,6 @@ def test_process_in_game_bot_starts_game_when_host(monkeypatch):
     assert table.game.actions == [("BotA", "start_game")]
 
 
-def test_process_leaving_game_logout_branch(monkeypatch):
-    manager = VirtualBotManager(FakeServer())
-    bot = VirtualBot("Leaf", state=VirtualBotState.LEAVING_GAME)
-    bot.logout_after_game = True
-    bot.online_ticks = 10
-    bot.target_online_ticks = 999
-    manager._bots["Leaf"] = bot
-    monkeypatch.setattr("server.core.virtual_bots.random.randint", lambda a, b: a)
-
-    manager._process_leaving_game_bot(bot)
-
-    assert bot.state == VirtualBotState.ONLINE_IDLE
-    assert bot.cooldown_ticks == manager._get_config_value(bot, "logout_after_game_min_ticks")
-
-
-def test_process_leaving_game_offline_path(monkeypatch):
-    manager = VirtualBotManager(FakeServer())
-    bot = VirtualBot("Leaf", state=VirtualBotState.LEAVING_GAME)
-    bot.logout_after_game = False
-    bot.online_ticks = 100
-    bot.target_online_ticks = 50
-    manager._bots["Leaf"] = bot
-    taken_offline = {}
-
-    def fake_take(target_bot):
-        taken_offline["bot"] = target_bot
-        target_bot.state = VirtualBotState.OFFLINE
-
-    monkeypatch.setattr(manager, "_take_bot_offline", fake_take)
-
-    manager._process_leaving_game_bot(bot)
-
-    assert taken_offline["bot"] is bot
-    assert bot.state == VirtualBotState.OFFLINE
-
-
 def test_on_tick_processes_all_bots(monkeypatch):
     manager = _make_single_bot_manager(["BotA", "BotB"])
     calls = []


### PR DESCRIPTION
## Summary

Pre-existing lint cleanup in the server tree (none of these were introduced by an open PR; the repo's gated ruff set E9/F63/F7 stays clean, but a broader scan surfaced these).

**Resolves all 14 ruff `F821` undefined-name errors:**
- Three were genuine **wrong class names** in string annotations and would `NameError` under `typing.get_type_hints()`:
  - `AuthUserRecord` → `UserRecord` (`core/server.py`)
  - `GuidedTableRuleState` → `GuidedTableState` (`core/virtual_bots.py`, ×3)
  - `ChaosPlayer` → `ChaosBearPlayer` (`games/chaosbear/game.py`)
- The rest were correct names missing their type-only imports: `Table`, `TribeState`, `GnubgProcess`, `SorryPawnState`.

**Removes three dead duplicate definitions** that Python silently shadowed, so they never executed:
- `test_process_leaving_game_logout_branch` and `test_process_leaving_game_offline_path` (redefined later in `test_virtual_bots.py`)
- a doubled `save_state` method in a test fake (`test_server_admin_virtual_bots.py`)

The surviving copies assert equivalent outcomes, so no coverage is lost.

## Testing

- `uvx ruff check server --select F821` → **All checks passed** (was 14 errors)
- `uv run --extra dev pytest tests/test_virtual_bots.py tests/test_server_admin_virtual_bots.py` → **91 passed**
- `uv run --extra dev pytest tests/test_ageofheroes.py tests/test_backgammon.py tests/test_chaosbear.py tests/test_sorry.py` → **145 passed**
- Import smoke of all touched modules → no import errors / cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)